### PR TITLE
feat: state getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ the value encoding of the underlying Hypercore is `binary` or `utf-8`, this will
 be the byte length of all the blocks in the batch. If the value encoding is
 `json` then this will be the number of entries in a batch.
 
+### indexer.state
+
+Type: `IndexState: { current: 'idle' | 'indexing', remaining: number, entriesPerSecond: number }`
+
+A getter that returns the current `IndexState`, the same as the value emitted by the `index-state` event. This getter is useful for checking the state of the indexer before it has emitted any events.
+
 ### indexer.addCore(core)
 
 #### core

--- a/index.js
+++ b/index.js
@@ -76,6 +76,17 @@ class MultiCoreIndexer extends TypedEmitter {
   }
 
   /**
+   * @type {IndexState}
+   */
+  get state() {
+    return {
+      current: this.#state,
+      entriesPerSecond: this.#rate,
+      remaining: this.#lastRemaining,
+    }
+  }
+
+  /**
    * Add a core to be indexed
    * @param {import('hypercore')<T>} core
    */

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -93,14 +93,22 @@ async function throttledIdle(emitter) {
   return new Promise((resolve) => {
     /** @type {ReturnType<setTimeout>} */
     let timeoutId
-    emitter.on('idle', function onIdle() {
+
+    /* @ts-ignore: we're using this helper with both MultiCoreIndexer and an indexer stream. checking that the state property exists is sufficient. */
+    if (emitter.state && emitter.state.current === 'idle') {
+      onIdle()
+    }
+
+    function onIdle() {
       clearTimeout(timeoutId)
       timeoutId = setTimeout(() => {
         emitter.off('idle', onIdle)
         emitter.off('indexing', onIndexing)
         resolve()
-      }, 200)
-    })
+      }, 10)
+    }
+
+    emitter.on('idle', onIdle)
     emitter.on('indexing', onIndexing)
     function onIndexing() {
       clearTimeout(timeoutId)

--- a/test/multi-core-indexer.test.js
+++ b/test/multi-core-indexer.test.js
@@ -315,3 +315,23 @@ test('sync state / progress', async (t) => {
   await indexer.close()
   t.pass('Indexer closed')
 })
+
+test('state getter', async (t) => {
+  const cores = await createMultiple(2)
+  const entries = []
+  const indexer = new MultiCoreIndexer(cores, {
+    batch: async (data) => {
+      entries.push(...data)
+    },
+    storage: () => ram(),
+  })
+  t.same(indexer.state.current, 'idle')
+  await throttledIdle(indexer)
+  await generateFixtures(cores, 100)
+  t.same(indexer.state.current, 'indexing')
+  await throttledIdle(indexer)
+  t.same(indexer.state.current, 'idle')
+  t.same(entries.length, 200)
+  await indexer.close()
+  t.pass('Indexer closed')
+})


### PR DESCRIPTION
closes #4 

This adds an `indexer.state` getter that returns the same object as the `index-state` event for accessing the current state of the indexer. I like a getter for this as doing something like `indexer.state.current === 'idle'` feels more appropriate than calling a method.