### PR TITLE
fix: correctly track & persist index state

### DIFF
--- a/lib/bitfield.js
+++ b/lib/bitfield.js
@@ -46,15 +46,15 @@ class FixedBitfield {
 class Bitfield {
   /**
    *
-   * @param {import('random-access-storage')} storage
-   * @param {Buffer | null} buf
+   * @param {import('random-access-storage')} [storage]
+   * @param {Buffer} [buf]
    */
   constructor(storage, buf) {
     this.pageSize = 32768
     /** @type {BigSparseArray<FixedBitfield>} */
     this.pages = new BigSparseArray()
-    /** @type {Array<FixedBitfield>} */
-    this.unflushed = []
+    /** @type {Array<FixedBitfield> | undefined} */
+    this.unflushed = storage ? [] : undefined
     this.storage = storage
 
     const all =
@@ -102,12 +102,13 @@ class Bitfield {
     if (!p.set(j, val) || p.dirty) return
 
     p.dirty = true
-    this.unflushed.push(p)
+    this.unflushed?.push(p)
   }
 
   /** @returns {Promise<void>} */
   clear() {
     return new Promise((resolve, reject) => {
+      if (!this.storage) return resolve()
       this.storage.del(0, Infinity, (err) => {
         if (err) reject(err)
         else resolve()
@@ -118,6 +119,7 @@ class Bitfield {
   /** @returns {Promise<void>} */
   close() {
     return new Promise((resolve, reject) => {
+      if (!this.storage) return resolve()
       this.storage.close((err) => {
         if (err) reject(err)
         else resolve()
@@ -128,7 +130,8 @@ class Bitfield {
   /** @returns {Promise<void>} */
   flush() {
     return new Promise((resolve, reject) => {
-      if (!this.unflushed.length) return resolve()
+      if (!this.storage) return resolve()
+      if (!this.unflushed?.length) return resolve()
 
       const self = this
       let missing = this.unflushed.length
@@ -157,15 +160,15 @@ class Bitfield {
   }
 
   /**
-   * @param {ConstructorParameters<typeof Bitfield>[0]} storage
+   * @param {import('random-access-storage')} storage
    * @returns {Promise<Bitfield>}
    */
   static open(storage) {
     return new Promise((resolve, reject) => {
       storage.stat((err, st) => {
-        if (err) return resolve(new Bitfield(storage, null))
+        if (err) return resolve(new Bitfield(storage))
         const size = st.size - (st.size & 3)
-        if (!size) return resolve(new Bitfield(storage, null))
+        if (!size) return resolve(new Bitfield(storage))
         storage.read(0, size, (err, data) => {
           if (err) return reject(err)
           resolve(new Bitfield(storage, data))

--- a/lib/core-index-stream.js
+++ b/lib/core-index-stream.js
@@ -31,7 +31,10 @@ const kUpdateState = Symbol('updateState')
  */
 class CoreIndexStream extends Readable {
   /** @type {Bitfield | undefined} */
-  #bitfield
+  #indexedBitfield
+  /** @type {Bitfield | undefined} */
+  #inProgressBitfield
+  #inProgress = 0
   #core
   #storage
   #index = 0
@@ -56,6 +59,7 @@ class CoreIndexStream extends Readable {
       byteLength: () => 1,
     })
     this.#core = core
+    this.id = core.key.toString('hex')
     this.#storage = storage
     this[kHandleAppend] = this[kHandleAppend].bind(this)
     this[kHandleDownload] = this[kHandleDownload].bind(this)
@@ -63,13 +67,7 @@ class CoreIndexStream extends Readable {
 
   get remaining() {
     return (
-      this.#core.length -
-      this.#index +
-      this.#downloaded.size +
-      // For an external consumer of this stream, items in the stream's buffer
-      // are still "remaining" ie they will not have been read by the "consumer"
-      // @ts-ignore - internal undocumented property
-      this._readableState.buffered
+      this.#core.length - this.#index + this.#downloaded.size + this.#inProgress
     )
   }
 
@@ -97,16 +95,28 @@ class CoreIndexStream extends Readable {
     this[kDestroyPromise]().then(cb, cb)
   }
 
+  /**
+   * Set a block as indexed, removes it from "inProgress"
+   *
+   * @param {number} index
+   */
+  setIndexed(index) {
+    this.#inProgress--
+    this.#indexedBitfield?.set(index, true)
+    this.#inProgressBitfield?.set(index, false)
+  }
+
   async [kDestroyPromise]() {
     this.#core.removeListener('append', this[kHandleAppend])
     this.#core.removeListener('download', this[kHandleDownload])
-    await this.#bitfield?.flush()
+    await this.#indexedBitfield?.flush()
   }
 
   async [kOpenPromise]() {
     this.#state = 'indexing'
     this.emit('indexing')
-    this.#bitfield = await Bitfield.open(this.#storage)
+    this.#indexedBitfield = await Bitfield.open(this.#storage)
+    this.#inProgressBitfield = await new Bitfield()
     await this.#core.update({ wait: true })
     this.#core.on('append', this[kHandleAppend])
     this.#core.on('download', this[kHandleDownload])
@@ -148,7 +158,7 @@ class CoreIndexStream extends Readable {
       // If nothing was pushed, queue up another read
       await this[kReadPromise]()
     }
-    await this.#bitfield?.flush()
+    await this.#indexedBitfield?.flush()
   }
 
   /**
@@ -158,11 +168,13 @@ class CoreIndexStream extends Readable {
    * @returns {Promise<boolean>}
    */
   async [kPushEntry](index) {
-    const isIndexed = this.#bitfield?.get(index)
-    if (isIndexed) return false
+    const isProcessed =
+      this.#indexedBitfield?.get(index) || this.#inProgressBitfield?.get(index)
+    if (isProcessed) return false
     const block = await this.#core.get(index, { wait: false })
     if (block === null) return false
-    this.#bitfield?.set(index, true)
+    this.#inProgressBitfield?.set(index, true)
+    this.#inProgress++
     const entry = { key: this.#core.key, block, index }
     this.#readBufferAvailable = this.push(entry)
     return true

--- a/lib/multi-core-index-stream.js
+++ b/lib/multi-core-index-stream.js
@@ -26,6 +26,8 @@ const kUpdateState = Symbol('updateState')
 class MultiCoreIndexStream extends Readable {
   /** @type {Map<CoreIndexStream<T>, () => void>} */
   #streams = new Map()
+  /** @type {Map<string, CoreIndexStream<T>>} */
+  #streamsById = new Map()
   /** @type {Set<CoreIndexStream<T>>} */
   #readable = new Set()
   #pending = pDefer()
@@ -57,11 +59,19 @@ class MultiCoreIndexStream extends Readable {
     for (const stream of this.#streams.keys()) {
       remaining += stream.remaining
     }
-    return (
-      remaining +
-      // @ts-ignore - reading internal buffer size, which is undocumented
-      this._readableState.buffered
-    )
+    return remaining
+  }
+
+  /**
+   *
+   * @param {string} streamId hex-encoded core key
+   * @param {number} index index of block that has been indexed
+   */
+  setIndexed(streamId, index) {
+    const stream = this.#streamsById.get(streamId)
+    /* istanbul ignore next: this should always be true */
+    if (!stream) return
+    stream.setIndexed(index)
   }
 
   /**
@@ -74,6 +84,7 @@ class MultiCoreIndexStream extends Readable {
     // Do this so that we can remove this listener when we destroy the stream
     const handleReadableFn = this[kHandleReadable].bind(this, stream)
     this.#streams.set(stream, handleReadableFn)
+    this.#streamsById.set(stream.id, stream)
     this.#readable.add(stream)
     stream.on('readable', handleReadableFn)
     stream.on('indexing', this[kHandleIndexing])

--- a/test/unit-tests/bitfield.test.js
+++ b/test/unit-tests/bitfield.test.js
@@ -22,6 +22,24 @@ test('bitfield - set and get', async function (t) {
   await b.flush()
 })
 
+test('bitfield - set and get, no storage', async function (t) {
+  const b = await new Bitfield()
+
+  t.notOk(b.get(42))
+  b.set(42, true)
+  t.ok(b.get(42))
+
+  // bigger offsets
+  t.notOk(b.get(42000000))
+  b.set(42000000, true)
+  t.ok(b.get(42000000))
+
+  b.set(42000000, false)
+  t.notOk(b.get(42000000))
+
+  await b.flush()
+})
+
 test('bitfield - random set and gets', async function (t) {
   const b = await Bitfield.open(new ram())
   const set = new Set()

--- a/test/unit-tests/core-index-stream.test.js
+++ b/test/unit-tests/core-index-stream.test.js
@@ -41,6 +41,7 @@ test('.remaining property is accurate', async (t) => {
   t.equal(stream.remaining, totalBlocks)
   stream.on('data', (entry) => {
     entries.push(entry)
+    stream.setIndexed(entry.index)
     t.equal(stream.remaining + entries.length, totalBlocks)
   })
   await once(stream, 'idle')
@@ -152,7 +153,10 @@ test('Maintains index state', async (t) => {
   const entries = []
   const storage = new ram()
   const stream1 = new CoreIndexStream(a, storage)
-  stream1.on('data', (entry) => entries.push(entry.block))
+  stream1.on('data', (entry) => {
+    entries.push(entry.block)
+    stream1.setIndexed(entry.index)
+  })
 
   const blocks = generateFixture(0, 1000)
   await a.append(blocks.slice(0, 500))
@@ -162,7 +166,10 @@ test('Maintains index state', async (t) => {
   await once(stream1, 'close')
   await a.append(blocks.slice(500, 1000))
   const stream2 = new CoreIndexStream(a, storage)
-  stream2.on('data', (entry) => entries.push(entry.block))
+  stream2.on('data', (entry) => {
+    entries.push(entry.block)
+    stream2.setIndexed(entry.index)
+  })
   await throttledIdle(stream2)
   t.same(entries.sort(), blocks.sort())
 })


### PR DESCRIPTION
Currently entries are marked as "indexed" in the indexer state (including the persisted index) as soon as they are read, rather than once they are indexed in the `batch()` function.

This PR fixes:

- https://github.com/digidem/multi-core-indexer/issues/12
- https://github.com/digidem/multi-core-indexer/issues/13

The fix is to consider an entry "in progress" until the batch function resolves, only then is it marked as "indexed".

This PR includes a perhaps unnecessary in-memory bitfield for tracking in-progress entries. This would only be needed if the code tries to re-index an entry that is in progress but has not yet been indexed. I can't think of a scenario where this would happen, but keeping the tracking just to be certain a bug from this will not creep in.

This PR does not implement a way to retry entries from a failed `batch()`, e.g. when `batch()` throws an error. Current behaviour is that an error in `batch()` will cause the indexer to fail. Tracking how to handle errors in a separate issue #15 
