### PR TITLE
Use iterables directly instead of using `.values()`

### DIFF
--- a/benchmarks/multifeed-index.js
+++ b/benchmarks/multifeed-index.js
@@ -62,7 +62,7 @@ async function createCores(multi, count) {
 async function generateFixtures(cores, count) {
   /** @type {Entry[]} */
   const entries = []
-  for (const core of cores.values()) {
+  for (const core of cores) {
     const offset = core.length
     const blocks = generateFixture(offset, offset + count)
     await promisify(core.append.bind(core))(blocks)

--- a/lib/core-index-stream.js
+++ b/lib/core-index-stream.js
@@ -148,7 +148,7 @@ class CoreIndexStream extends Readable {
     }
     // Still space in the read buffer? Process any downloaded blocks
     if (this.#readBufferAvailable) {
-      for (const index of this.#downloaded.values()) {
+      for (const index of this.#downloaded) {
         this.#downloaded.delete(index)
         didPush =
           (await this[kPushEntry](index)) ||

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -74,7 +74,7 @@ function generateFixture(start, end) {
 async function generateFixtures(cores, count) {
   /** @type {Entry[]} */
   const entries = []
-  for (const core of cores.values()) {
+  for (const core of cores) {
     const offset = core.length
     const blocks = generateFixture(offset, offset + count)
     await core.append(blocks)

--- a/test/unit-tests/multi-core-index-stream.test.js
+++ b/test/unit-tests/multi-core-index-stream.test.js
@@ -182,7 +182,7 @@ test('Appends from a replicated core are indexed', async (t) => {
   t.same(sortEntries(entries), sortEntries(expected1))
 
   const expected2 = await generateFixtures(localCores, 50)
-  for (const remote of remoteCores.values()) {
+  for (const remote of remoteCores) {
     remote.download({ start: 0, end: remote.length })
   }
   await throttledDrain(stream)


### PR DESCRIPTION
This change should have no user impact.

This replaces the use of `Array.prototype.values()` and `Set.prototype.values()` with the iterables themselves, as `.values()` is redundant. To quote [MDN's docs][0]:

> `Array.prototype.values()` is the default implementation of `Array.prototype[@@iterator]()`.

MDN [says something similar for `Set`][1].

`git grep -F '.values()'` returns no results after this change.

[0]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/values#description
[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/@@iterator#return_value
