### PR TITLE
Use private methods instead of symbol keys

### DIFF
--- a/lib/core-index-stream.js
+++ b/lib/core-index-stream.js
@@ -4,11 +4,8 @@ const Bitfield = require('./bitfield')
 const { pDefer } = require('./utils')
 const { promisify } = require('node:util')
 
-const kOpenPromise = Symbol('openPromise')
-const kDestroyPromise = Symbol('destroyPromise')
 const kHandleAppend = Symbol('handleAppend')
 const kHandleDownload = Symbol('handleDownload')
-const kPushEntry = Symbol('pushEntry')
 
 /** @typedef {import('./types').ValueEncoding} ValueEncoding */
 /** @typedef {import('./types').JSONValue} JSONValue */
@@ -80,7 +77,7 @@ class CoreIndexStream extends Readable {
 
   /** @param {any} cb */
   _open(cb) {
-    this[kOpenPromise]().then(cb, cb)
+    this.#open().then(cb, cb)
   }
 
   /** @param {any} cb */
@@ -95,7 +92,7 @@ class CoreIndexStream extends Readable {
 
   /** @param {any} cb */
   _destroy(cb) {
-    this[kDestroyPromise]().then(cb, cb)
+    this.#destroy().then(cb, cb)
   }
 
   /**
@@ -109,14 +106,14 @@ class CoreIndexStream extends Readable {
     this.#inProgressBitfield?.set(index, false)
   }
 
-  async [kDestroyPromise]() {
+  async #destroy() {
     this.#core.removeListener('append', this[kHandleAppend])
     this.#core.removeListener('download', this[kHandleDownload])
     await this.#indexedBitfield?.flush()
     if (this.#storage) await closeStorage(this.#storage)
   }
 
-  async [kOpenPromise]() {
+  async #open() {
     await this.#core.ready()
     await this.#core.update({ wait: true })
     const { discoveryKey } = this.#core
@@ -141,7 +138,7 @@ class CoreIndexStream extends Readable {
     let didPush = false
     this.#readBufferAvailable = true
     while (this.#readBufferAvailable && this.#index < this.#core.length) {
-      didPush = (await this[kPushEntry](this.#index)) || didPush
+      didPush = (await this.#pushEntry(this.#index)) || didPush
       // Don't increment this until after the async push above
       this.#index++
     }
@@ -150,7 +147,7 @@ class CoreIndexStream extends Readable {
       for (const index of this.#downloaded) {
         this.#downloaded.delete(index)
         didPush =
-          (await this[kPushEntry](index)) ||
+          (await this.#pushEntry(index)) ||
           /* istanbul ignore next - TODO: Test when hypercore-next supports a core.clear() method */
           didPush
         // This is for back-pressure, for which there is not a good test yet.
@@ -176,7 +173,7 @@ class CoreIndexStream extends Readable {
    * @param {number} index
    * @returns {Promise<boolean>}
    */
-  async [kPushEntry](index) {
+  async #pushEntry(index) {
     const isProcessed =
       this.#indexedBitfield?.get(index) || this.#inProgressBitfield?.get(index)
     if (isProcessed) return false

--- a/lib/core-index-stream.js
+++ b/lib/core-index-stream.js
@@ -4,7 +4,6 @@ const Bitfield = require('./bitfield')
 const { pDefer } = require('./utils')
 const { promisify } = require('node:util')
 
-const kReadPromise = Symbol('readPromise')
 const kOpenPromise = Symbol('openPromise')
 const kDestroyPromise = Symbol('destroyPromise')
 const kHandleAppend = Symbol('handleAppend')
@@ -86,7 +85,7 @@ class CoreIndexStream extends Readable {
 
   /** @param {any} cb */
   _read(cb) {
-    this[kReadPromise]().then(cb, cb)
+    this.#read().then(cb, cb)
   }
 
   _predestroy() {
@@ -130,7 +129,7 @@ class CoreIndexStream extends Readable {
     this.#core.on('download', this[kHandleDownload])
   }
 
-  async [kReadPromise]() {
+  async #read() {
     if (this.#index >= this.#core.length && this.#downloaded.size === 0) {
       this.#drained = true
       this.emit('drained')
@@ -166,7 +165,7 @@ class CoreIndexStream extends Readable {
     }
     if (!didPush && !this.#destroying) {
       // If nothing was pushed, queue up another read
-      await this[kReadPromise]()
+      await this.#read()
     }
     await this.#indexedBitfield?.flush()
   }

--- a/lib/core-index-stream.js
+++ b/lib/core-index-stream.js
@@ -4,9 +4,6 @@ const Bitfield = require('./bitfield')
 const { pDefer } = require('./utils')
 const { promisify } = require('node:util')
 
-const kHandleAppend = Symbol('handleAppend')
-const kHandleDownload = Symbol('handleDownload')
-
 /** @typedef {import('./types').ValueEncoding} ValueEncoding */
 /** @typedef {import('./types').JSONValue} JSONValue */
 /**
@@ -26,6 +23,8 @@ const kHandleDownload = Symbol('handleDownload')
  * @extends {Readable<Entry<T>, Entry<T>, Entry<T>, true, false, import('./types').IndexStreamEvents<Entry<T>>>}
  */
 class CoreIndexStream extends Readable {
+  #handleAppendBound
+  #handleDownloadBound
   /** @type {Bitfield | undefined} */
   #indexedBitfield
   /** @type {Bitfield | undefined} */
@@ -57,8 +56,8 @@ class CoreIndexStream extends Readable {
     })
     this.#core = core
     this.#createStorage = createStorage
-    this[kHandleAppend] = this[kHandleAppend].bind(this)
-    this[kHandleDownload] = this[kHandleDownload].bind(this)
+    this.#handleAppendBound = this.#handleAppend.bind(this)
+    this.#handleDownloadBound = this.#handleDownload.bind(this)
   }
 
   get remaining() {
@@ -107,8 +106,8 @@ class CoreIndexStream extends Readable {
   }
 
   async #destroy() {
-    this.#core.removeListener('append', this[kHandleAppend])
-    this.#core.removeListener('download', this[kHandleDownload])
+    this.#core.removeListener('append', this.#handleAppendBound)
+    this.#core.removeListener('download', this.#handleDownloadBound)
     await this.#indexedBitfield?.flush()
     if (this.#storage) await closeStorage(this.#storage)
   }
@@ -122,8 +121,8 @@ class CoreIndexStream extends Readable {
     this.#storage = this.#createStorage(getStorageName(discoveryKey))
     this.#indexedBitfield = await Bitfield.open(this.#storage)
     this.#inProgressBitfield = await new Bitfield()
-    this.#core.on('append', this[kHandleAppend])
-    this.#core.on('download', this[kHandleDownload])
+    this.#core.on('append', this.#handleAppendBound)
+    this.#core.on('download', this.#handleDownloadBound)
   }
 
   async #read() {
@@ -188,14 +187,14 @@ class CoreIndexStream extends Readable {
     return true
   }
 
-  async [kHandleAppend]() {
+  async #handleAppend() {
     this.#pending.resolve()
   }
 
   /**
    * @param {number} index
    */
-  async [kHandleDownload](index) {
+  async #handleDownload(index) {
     this.#downloaded.add(index)
     this.#pending.resolve()
   }

--- a/lib/multi-core-index-stream.js
+++ b/lib/multi-core-index-stream.js
@@ -13,9 +13,6 @@ const { once } = require('events')
  * @template {ValueEncoding} [T='binary']
  * @typedef {import('./core-index-stream').CoreIndexStream<T>} CoreIndexStream
  */
-const kReadPromise = Symbol('readPromise')
-const kHandleReadable = Symbol('handleReadable')
-const kDestroyPromise = Symbol('destroyPromise')
 const kHandleIndexing = Symbol('handleIndexing')
 const kHandleDrained = Symbol('handleDrained')
 
@@ -89,7 +86,7 @@ class MultiCoreIndexStream extends Readable {
     if (this.#streams.has(stream)) return
     this.#drained = false
     // Do this so that we can remove this listener when we destroy the stream
-    const handleReadableFn = this[kHandleReadable].bind(this, stream)
+    const handleReadableFn = this.#handleReadable.bind(this, stream)
     this.#streams.set(stream, handleReadableFn)
     stream.core
       .ready()
@@ -113,7 +110,7 @@ class MultiCoreIndexStream extends Readable {
 
   /** @param {any} cb */
   _read(cb) {
-    this[kReadPromise]().then(cb, cb)
+    this.#read().then(cb, cb)
   }
 
   _predestroy() {
@@ -123,10 +120,10 @@ class MultiCoreIndexStream extends Readable {
 
   /** @param {any} cb */
   _destroy(cb) {
-    this[kDestroyPromise]().then(cb, cb)
+    this.#destroy().then(cb, cb)
   }
 
-  async [kDestroyPromise]() {
+  async #destroy() {
     const closePromises = []
     for (const [stream, handleReadableFn] of this.#streams) {
       stream.off('readable', handleReadableFn)
@@ -138,7 +135,7 @@ class MultiCoreIndexStream extends Readable {
     await Promise.all(closePromises)
   }
 
-  async [kReadPromise]() {
+  async #read() {
     let didPush = false
     if (!this.#readable.size && !this.#destroying) {
       await (this.#pending = pDefer()).promise
@@ -156,12 +153,12 @@ class MultiCoreIndexStream extends Readable {
     }
     if (!didPush && !this.#destroying) {
       // If nothing was pushed, queue up another read
-      await this[kReadPromise]()
+      await this.#read()
     }
   }
 
   /** @param {CoreIndexStream<T>} stream */
-  [kHandleReadable](stream) {
+  #handleReadable(stream) {
     this.#readable.add(stream)
     this.#pending.resolve()
   }

--- a/lib/multi-core-index-stream.js
+++ b/lib/multi-core-index-stream.js
@@ -13,14 +13,14 @@ const { once } = require('events')
  * @template {ValueEncoding} [T='binary']
  * @typedef {import('./core-index-stream').CoreIndexStream<T>} CoreIndexStream
  */
-const kHandleIndexing = Symbol('handleIndexing')
-const kHandleDrained = Symbol('handleDrained')
 
 /**
  * @template {ValueEncoding} [T='binary']
  * @extends {Readable<Entry<T>, Entry<T>, Entry<T>, true, false, import('./types').IndexStreamEvents<Entry<T>>>}
  */
 class MultiCoreIndexStream extends Readable {
+  #handleIndexingBound
+  #handleDrainedBound
   /** @type {Map<CoreIndexStream<T>, () => void>} */
   #streams = new Map()
   /** @type {Map<string, CoreIndexStream<T>>} */
@@ -46,8 +46,8 @@ class MultiCoreIndexStream extends Readable {
       byteLength: () => 1,
     })
     this.#drained = streams.length === 0
-    this[kHandleIndexing] = this[kHandleIndexing].bind(this)
-    this[kHandleDrained] = this[kHandleDrained].bind(this)
+    this.#handleIndexingBound = this.#handleIndexing.bind(this)
+    this.#handleDrainedBound = this.#handleDrained.bind(this)
     for (const s of streams) {
       this.addStream(s)
     }
@@ -99,8 +99,8 @@ class MultiCoreIndexStream extends Readable {
       .catch(noop)
     this.#readable.add(stream)
     stream.on('readable', handleReadableFn)
-    stream.on('indexing', this[kHandleIndexing])
-    stream.on('drained', this[kHandleDrained])
+    stream.on('indexing', this.#handleIndexingBound)
+    stream.on('drained', this.#handleDrainedBound)
   }
 
   /** @param {any} cb */
@@ -127,8 +127,8 @@ class MultiCoreIndexStream extends Readable {
     const closePromises = []
     for (const [stream, handleReadableFn] of this.#streams) {
       stream.off('readable', handleReadableFn)
-      stream.off('indexing', this[kHandleIndexing])
-      stream.off('drained', this[kHandleDrained])
+      stream.off('indexing', this.#handleIndexingBound)
+      stream.off('drained', this.#handleDrainedBound)
       stream.destroy()
       closePromises.push(once(stream, 'close'))
     }
@@ -167,13 +167,13 @@ class MultiCoreIndexStream extends Readable {
   // `indexing` event always fires at the start of indexing in the chain of
   // streams (the `drained` event should happen at the end of the chain once
   // everything is read)
-  [kHandleIndexing]() {
+  #handleIndexing() {
     if (!this.#drained) return
     this.#drained = false
     this.emit('indexing')
   }
 
-  [kHandleDrained]() {
+  #handleDrained() {
     let drained = true
     for (const stream of this.#streams.keys()) {
       if (!stream.drained) drained = false


### PR DESCRIPTION
This change should have no user impact.

Before:

```javascript
const kBar = Symbol('bar')

class Foo {
  [kBar]() { /* do something */ }

  twoBars() {
    this[kBar]()
    this[kBar]()
  }
}
```

After:

```javascript
class Foo {
  #bar() { /* do something */ }

  twoBars() {
    this.#bar()
    this.#bar()
  }
}
```