### PR TITLE
chore: remove unused "last remaining" member

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ class MultiCoreIndexer extends TypedEmitter {
   #batch
   /** @type {import('./lib/types').IndexStateCurrent} */
   #state = 'indexing'
-  #lastRemaining = -1
   #rateMeasurementStart = Date.now()
   #rate = 0
   #createStorage


### PR DESCRIPTION
It looks like the last usage of this was removed in 89ac7ae4551b75713ca2a13c3a5e2eb741eb4519.

This change is not urgent.