### PR TITLE
feat: add method to unlink storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ hypercores already in the indexer.
 Stop the indexer and flush index state to storage. This will not close the
 underlying storage - it is up to the consumer to do that.
 
+### indexer.unlink()
+
+Unlink all index files. This should only be called after `close()` has resolved.
+
 ### indexer.on('index-state', onState)
 
 #### onState

--- a/index.js
+++ b/index.js
@@ -116,6 +116,13 @@ class MultiCoreIndexer extends TypedEmitter {
     ])
   }
 
+  /**
+   * Unlink all index files. This should only be called after `close()` has resolved.
+   */
+  async unlink() {
+    await this.#indexStream.unlink()
+  }
+
   /** @param {Entry<T>[]} entries */
   async #handleEntries(entries) {
     this.#emitState()

--- a/lib/core-index-stream.js
+++ b/lib/core-index-stream.js
@@ -55,9 +55,15 @@ class CoreIndexStream extends Readable {
       byteLength: () => 1,
     })
     this.#core = core
-    this.#createStorage = createStorage
     this.#handleAppendBound = this.#handleAppend.bind(this)
     this.#handleDownloadBound = this.#handleDownload.bind(this)
+    this.#createStorage = async () => {
+      await this.#core.ready()
+      const { discoveryKey } = this.#core
+      /* istanbul ignore next: just to keep TS happy - after core.ready() this is set */
+      if (!discoveryKey) throw new Error('Missing discovery key')
+      return createStorage(getStorageName(discoveryKey))
+    }
   }
 
   get remaining() {
@@ -105,6 +111,11 @@ class CoreIndexStream extends Readable {
     this.#inProgressBitfield?.set(index, false)
   }
 
+  async unlink() {
+    this.#storage ??= await this.#createStorage()
+    await unlinkStorage(this.#storage)
+  }
+
   async #destroy() {
     this.#core.removeListener('append', this.#handleAppendBound)
     this.#core.removeListener('download', this.#handleDownloadBound)
@@ -115,10 +126,7 @@ class CoreIndexStream extends Readable {
   async #open() {
     await this.#core.ready()
     await this.#core.update({ wait: true })
-    const { discoveryKey } = this.#core
-    /* istanbul ignore next: just to keep TS happy - after core.ready() this is set */
-    if (!discoveryKey) throw new Error('Missing discovery key')
-    this.#storage = this.#createStorage(getStorageName(discoveryKey))
+    this.#storage ??= await this.#createStorage()
     this.#indexedBitfield = await Bitfield.open(this.#storage)
     this.#inProgressBitfield = await new Bitfield()
     this.#core.on('append', this.#handleAppendBound)
@@ -211,4 +219,9 @@ function getStorageName(discoveryKey) {
 /** @param {import('random-access-storage')} storage*/
 function closeStorage(storage) {
   return promisify(storage.close.bind(storage))()
+}
+
+/** @param {import('random-access-storage')} storage */
+function unlinkStorage(storage) {
+  return promisify(storage.unlink.bind(storage))()
 }

--- a/lib/multi-core-index-stream.js
+++ b/lib/multi-core-index-stream.js
@@ -103,6 +103,18 @@ class MultiCoreIndexStream extends Readable {
     stream.on('drained', this.#handleDrainedBound)
   }
 
+  /**
+   * Unlink all index files. This should only be called after close.
+   */
+  async unlink() {
+    /** @type {Array<Promise<unknown>>} */
+    const unlinkPromises = []
+    for (const stream of this.#streams.keys()) {
+      unlinkPromises.push(stream.unlink())
+    }
+    await Promise.all(unlinkPromises)
+  }
+
   /** @param {any} cb */
   _open(cb) {
     cb()


### PR DESCRIPTION
This adds `MultiCoreIndexer.prototype.unlink()` which unlinks all the index storage.

Addresses #26. Depends on #35 because it uses `??=`.
