### PR TITLE
perf: early return when handling "drained" event

### DIFF
--- a/lib/multi-core-index-stream.js
+++ b/lib/multi-core-index-stream.js
@@ -176,7 +176,10 @@ class MultiCoreIndexStream extends Readable {
   #handleDrained() {
     let drained = true
     for (const stream of this.#streams.keys()) {
-      if (!stream.drained) drained = false
+      if (!stream.drained) {
+        drained = false
+        break
+      }
     }
     if (drained === this.#drained && !drained) return
     this.#drained = drained


### PR DESCRIPTION
We only need to find one non-drained stream for this logic, so we can bail early if we find one. This should slightly improve performance.
