### PR TITLE
chore: add types for nanobench

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@digidem/types": "^1.0.1",
+        "@types/nanobench": "^3.0.0",
         "@types/sodium-native": "^2.3.5",
         "@types/tap": "^15.0.8",
         "brittle": "^3.3.2",
@@ -622,6 +623,12 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
+    },
+    "node_modules/@types/nanobench": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nanobench/-/nanobench-3.0.0.tgz",
+      "integrity": "sha512-ZLUczwWDAdILwoIigOJYHsuecrKqxq8tY3uVCgWLUkFNYIIIYQcFhrVwCOkDLDYOoXbwhxgfCWjszmHUEBGHMA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -9274,6 +9281,12 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
+    },
+    "@types/nanobench": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nanobench/-/nanobench-3.0.0.tgz",
+      "integrity": "sha512-ZLUczwWDAdILwoIigOJYHsuecrKqxq8tY3uVCgWLUkFNYIIIYQcFhrVwCOkDLDYOoXbwhxgfCWjszmHUEBGHMA==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@digidem/types": "^1.0.1",
+    "@types/nanobench": "^3.0.0",
     "@types/sodium-native": "^2.3.5",
     "@types/tap": "^15.0.8",
     "brittle": "^3.3.2",

--- a/vendor/types/nanobench.d.ts
+++ b/vendor/types/nanobench.d.ts
@@ -1,8 +1,0 @@
-declare module 'nanobench' {
-  interface Bench {
-    start(): void
-    end(): void
-  }
-  function nanobench(name: string, fn: (b: Bench) => void): void
-  export = nanobench
-}


### PR DESCRIPTION
Types for nanobench were [recently added to DefinitelyTyped][0], so we can use them.

The `benchmarks` directory is not currently type-checked, so this change primarily impacts editor tools.

Similar to [another change in mapeo-core-next][1].

[0]: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68221
[1]: https://github.com/digidem/mapeo-core-next/pull/441
