### PR TITLE
chore!: drop Node 16 support

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.17.1, 18.17.1, 20.x]
+        node-version: [18.17.1, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
This removes Node 16 support, given that (1) it is deprecated (2) it [is no longer used in CoMapeo][0].

[0]: https://github.com/digidem/CoMapeo-mobile/pull/194