### PR TITLE
chore: remove unused method from Bitfield class

### DIFF
--- a/lib/bitfield.js
+++ b/lib/bitfield.js
@@ -106,17 +106,6 @@ class Bitfield {
   }
 
   /** @returns {Promise<void>} */
-  clear() {
-    return new Promise((resolve, reject) => {
-      if (!this.storage) return resolve()
-      this.storage.del(0, Infinity, (err) => {
-        if (err) reject(err)
-        else resolve()
-      })
-    })
-  }
-
-  /** @returns {Promise<void>} */
   close() {
     return new Promise((resolve, reject) => {
       if (!this.storage) return resolve()


### PR DESCRIPTION
`Bitfield.prototype.clear` was never used, so we can remove it.