### PR TITLE
feat: reject if closed state is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ after the indexer is closed.
 Stop the indexer and flush index state to storage. This will not close the
 underlying storage - it is up to the consumer to do that.
 
+No-op if called more than once.
+
 ### indexer.unlink()
 
 Unlink all index files.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ be the byte length of all the blocks in the batch. If the value encoding is
 
 ### indexer.state
 
-Type: `IndexState: { current: 'idle' | 'indexing', remaining: number, entriesPerSecond: number }`
+Type: `IndexState: { current: 'idle' | 'indexing' | 'closing' | 'closed', remaining: number, entriesPerSecond: number }`
 
 A getter that returns the current `IndexState`, the same as the value emitted by the `index-state` event. This getter is useful for checking the state of the indexer before it has emitted any events.
 
@@ -139,6 +139,15 @@ Type: `Hypercore`
 Add a hypercore to the indexer. Must have the same value encoding as other
 hypercores already in the indexer.
 
+Rejects if called after the indexer is closed.
+
+### indexer.idle()
+
+Resolves when indexing state is `'idle'`.
+
+Resolves if the indexer is closed before this resolves. Rejects if called
+after the indexer is closed.
+
 ### indexer.close()
 
 Stop the indexer and flush index state to storage. This will not close the
@@ -146,7 +155,9 @@ underlying storage - it is up to the consumer to do that.
 
 ### indexer.unlink()
 
-Unlink all index files. This should only be called after `close()` has resolved.
+Unlink all index files.
+
+This should only be called after `close()` has resolved, and rejects if not.
 
 ### indexer.on('index-state', onState)
 

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ class MultiCoreIndexer extends TypedEmitter {
    * Stop the indexer and flush index state to storage. This will not close the
    * underlying storage - it is up to the consumer to do that.
    *
-   * Rejects if called more than once.
+   * No-op if called more than once.
    */
   async close() {
     if (!this.#isOpen()) return

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,6 @@
 import { ReadableEvents } from 'streamx'
 
-export type IndexStateCurrent = 'idle' | 'indexing'
+export type IndexStateCurrent = 'idle' | 'indexing' | 'closing' | 'closed'
 
 export interface IndexState {
   current: IndexStateCurrent

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,3 +12,13 @@ function pDefer() {
   return deferred
 }
 exports.pDefer = pDefer
+
+class ExhaustivenessError extends Error {
+  /** @param {never} value */
+  constructor(value) {
+    /* c8 ignore next 3 */
+    super(`Exhaustiveness check failed. ${value} should be impossible`)
+    this.name = 'ExhaustivenessError'
+  }
+}
+exports.ExhaustivenessError = ExhaustivenessError

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,9 +14,9 @@ function pDefer() {
 exports.pDefer = pDefer
 
 class ExhaustivenessError extends Error {
+  /* c8 ignore next 5 */
   /** @param {never} value */
   constructor(value) {
-    /* c8 ignore next 3 */
     super(`Exhaustiveness check failed. ${value} should be impossible`)
     this.name = 'ExhaustivenessError'
   }

--- a/test/multi-core-indexer.test.js
+++ b/test/multi-core-indexer.test.js
@@ -553,6 +553,17 @@ test('Closing before batch complete should resume on next start', async () => {
   await indexer2.close()
 })
 
+test('double-closing is a no-op', async (t) => {
+  const indexer = new MultiCoreIndexer([], {
+    batch: async () => {},
+    storage: () => new ram(),
+  })
+  const closePromise = indexer.close()
+  t.after(() => closePromise)
+
+  await assert.doesNotReject(() => indexer.close())
+})
+
 test('closing causes many methods to fail', async (t) => {
   {
     const indexer = new MultiCoreIndexer([], {
@@ -573,16 +584,6 @@ test('closing causes many methods to fail', async (t) => {
     const closePromise = indexer.close()
     t.after(() => closePromise)
     await assert.rejects(() => indexer.idle())
-  }
-
-  {
-    const indexer = new MultiCoreIndexer([], {
-      batch: async () => {},
-      storage: () => new ram(),
-    })
-    const closePromise = indexer.close()
-    t.after(() => closePromise)
-    await assert.rejects(() => indexer.close())
   }
 })
 

--- a/test/multi-core-indexer.test.js
+++ b/test/multi-core-indexer.test.js
@@ -95,7 +95,7 @@ test('Indexes items appended after initial index', async () => {
   await indexer.close()
 })
 
-test('No cores, starts idle, indexing after core added', async () => {
+test('State transitions', async () => {
   const indexer = new MultiCoreIndexer([], {
     batch: async () => {},
     storage: () => new ram(),
@@ -106,7 +106,19 @@ test('No cores, starts idle, indexing after core added', async () => {
   indexer.addCore(core)
   assert.equal(indexer.state.current, 'indexing', 'indexing after core added')
   await indexer.idle()
-  await indexer.close()
+  assert.equal(indexer.state.current, 'idle', 'returns to an idle state')
+  const closePromise = indexer.close()
+  assert.equal(
+    indexer.state.current,
+    'closing',
+    'moves to a "closing" state immediately after calling close'
+  )
+  await closePromise
+  assert.equal(
+    indexer.state.current,
+    'closed',
+    'moves to a "closed" state after closing'
+  )
 })
 
 test('Calling idle() when already idle still resolves', async () => {
@@ -539,6 +551,75 @@ test('Closing before batch complete should resume on next start', async () => {
   assert.equal(entries.length, expected.length)
   // t.same(sortEntries(entries), sortEntries(expected))
   await indexer2.close()
+})
+
+test('closing causes many methods to fail', async (t) => {
+  {
+    const indexer = new MultiCoreIndexer([], {
+      batch: async () => {},
+      storage: () => new ram(),
+    })
+    const closePromise = indexer.close()
+    t.after(() => closePromise)
+    const core = await create()
+    assert.throws(() => indexer.addCore(core))
+  }
+
+  {
+    const indexer = new MultiCoreIndexer([], {
+      batch: async () => {},
+      storage: () => new ram(),
+    })
+    const closePromise = indexer.close()
+    t.after(() => closePromise)
+    await assert.rejects(() => indexer.idle())
+  }
+
+  {
+    const indexer = new MultiCoreIndexer([], {
+      batch: async () => {},
+      storage: () => new ram(),
+    })
+    const closePromise = indexer.close()
+    t.after(() => closePromise)
+    await assert.rejects(() => indexer.close())
+  }
+})
+
+test('closing resolves existing idle promises', async () => {
+  const indexer = new MultiCoreIndexer([], {
+    batch: async () => {},
+    storage: () => new ram(),
+  })
+
+  const core = await create()
+  indexer.addCore(core)
+
+  const idlePromises = [indexer.idle(), indexer.idle(), indexer.idle()]
+
+  await indexer.close()
+
+  await assert.doesNotReject(() => Promise.all(idlePromises))
+})
+
+test('unlinking requires the indexer to be closed', async () => {
+  const indexer = new MultiCoreIndexer([], {
+    batch: async () => {},
+    storage: () => new ram(),
+  })
+
+  await indexer.idle()
+  await assert.rejects(() => indexer.unlink(), 'rejects when idle')
+
+  const core = await create()
+  indexer.addCore(core)
+  await assert.rejects(() => indexer.unlink(), 'rejects when indexing')
+
+  const closePromise = indexer.close()
+  await assert.rejects(() => indexer.unlink(), 'rejects when closing')
+
+  await closePromise
+  await assert.doesNotReject(() => indexer.unlink())
 })
 
 // This checks that storage names do not change between versions, which would be a breaking change

--- a/test/unit-tests/utils.test.js
+++ b/test/unit-tests/utils.test.js
@@ -1,0 +1,19 @@
+// @ts-check
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { ExhaustivenessError } = require('../../lib/utils.js')
+
+test('ExhaustivenessError', () => {
+  const bools = [true, false]
+  assert.doesNotThrow(() => {
+    bools.forEach((bool) => {
+      switch (bool) {
+        case true:
+        case false:
+          break
+        default:
+          throw new ExhaustivenessError(bool)
+      }
+    })
+  })
+})


### PR DESCRIPTION
Some methods, like `addCore()`, now throw if called after calling `close()`. `unlink()` is the opposite, and should only be called after the indexer is closed.

This is arguably a breaking change, but I feel that changing undefined behavior is not breaking.

Closes #21.