### PR TITLE
feat: reindexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ string, that should return a
 is used to store the index state of each hypercore. (Index state is stored as a
 bitfield).
 
+#### opts.reindex
+
+_Optional_\
+Type: `boolean`
+
+If `true`, the cores, and any new ones that are added, will be reindexed from
+scratch.
+
 #### opts.maxBatch
 
 _Optional_\

--- a/lib/core-index-stream.js
+++ b/lib/core-index-stream.js
@@ -45,8 +45,9 @@ class CoreIndexStream extends Readable {
   /**
    * @param {import('hypercore')<T, any>} core
    * @param {(name: string) => import('random-access-storage')} createStorage
+   * @param {boolean} reindex
    */
-  constructor(core, createStorage) {
+  constructor(core, createStorage, reindex) {
     super({
       // Treat as object stream, count each object as size `1` so that the
       // `remaining` property can use the stream buffer to calculate how many
@@ -59,10 +60,15 @@ class CoreIndexStream extends Readable {
     this.#handleDownloadBound = this.#handleDownload.bind(this)
     this.#createStorage = async () => {
       await this.#core.ready()
+
       const { discoveryKey } = this.#core
       /* c8 ignore next: just to keep TS happy - after core.ready() this is set */
       if (!discoveryKey) throw new Error('Missing discovery key')
-      return createStorage(getStorageName(discoveryKey))
+      const storageName = getStorageName(discoveryKey)
+
+      if (reindex) await unlinkStorage(createStorage(storageName))
+
+      return createStorage(storageName)
     }
   }
 

--- a/test/unit-tests/multi-core-index-stream.test.js
+++ b/test/unit-tests/multi-core-index-stream.test.js
@@ -19,7 +19,7 @@ test('Indexes all items already in a core', async () => {
   const cores = await createMultiple(5)
   const expected = await generateFixtures(cores, 1000)
   const indexStreams = cores.map(
-    (core) => new CoreIndexStream(core, () => new ram())
+    (core) => new CoreIndexStream(core, () => new ram(), false)
   )
   const entries = []
   const stream = new MultiCoreIndexStream(indexStreams)
@@ -44,7 +44,7 @@ test('Adding index streams after initialization', async () => {
   const cores = await createMultiple(3)
   const expected = await generateFixtures(cores, 100)
   const indexStreams = cores.map(
-    (core) => new CoreIndexStream(core, () => new ram())
+    (core) => new CoreIndexStream(core, () => new ram(), false)
   )
   const entries = []
   const stream = new MultiCoreIndexStream(indexStreams.slice(0, 2))
@@ -74,7 +74,7 @@ test('.remaining is as expected', async () => {
   const cores = await createMultiple(coreCount)
   const expected = await generateFixtures(cores, blockCount)
   const indexStreams = cores.map(
-    (core) => new CoreIndexStream(core, () => new ram())
+    (core) => new CoreIndexStream(core, () => new ram(), false)
   )
   const entries = []
   const stream = new MultiCoreIndexStream(indexStreams, { highWaterMark: 10 })
@@ -106,7 +106,7 @@ test('.remaining is as expected', async () => {
 test('Indexes items appended after initial index', async () => {
   const cores = await createMultiple(5)
   const indexStreams = cores.map(
-    (core) => new CoreIndexStream(core, () => new ram())
+    (core) => new CoreIndexStream(core, () => new ram(), false)
   )
   const entries = []
   const stream = new MultiCoreIndexStream(indexStreams, { highWaterMark: 10 })
@@ -138,7 +138,7 @@ test('index sparse hypercores', async () => {
   for (const core of remoteCores) {
     const range = core.download({ start: 5, end: 20 })
     await range.downloaded()
-    indexStreams.push(new CoreIndexStream(core, () => new ram()))
+    indexStreams.push(new CoreIndexStream(core, () => new ram(), false))
   }
   const entries = []
   const stream = new MultiCoreIndexStream(indexStreams, { highWaterMark: 10 })
@@ -172,7 +172,7 @@ test('Appends from a replicated core are indexed', async () => {
     await remote.update({ wait: true })
     const range = remote.download({ start: 0, end: remote.length })
     await range.downloaded()
-    indexStreams.push(new CoreIndexStream(core, () => new ram()))
+    indexStreams.push(new CoreIndexStream(core, () => new ram(), false))
   }
   const entries = []
   const stream = new MultiCoreIndexStream(indexStreams, { highWaterMark: 10 })
@@ -202,7 +202,7 @@ test('Maintains index state', async () => {
   for (const core of cores) {
     const storage = ram.reusable()
     storages.push(storage)
-    const indexStream = new CoreIndexStream(core, storage)
+    const indexStream = new CoreIndexStream(core, storage, false)
     indexStream.on('data', ({ index }) => {
       indexStream.setIndexed(index)
     })
@@ -211,7 +211,7 @@ test('Maintains index state', async () => {
   }
 
   const indexStreams = cores.map(
-    (core, i) => new CoreIndexStream(core, storages[i])
+    (core, i) => new CoreIndexStream(core, storages[i], false)
   )
   const stream = new MultiCoreIndexStream(indexStreams)
   stream.on('data', (entry) => {


### PR DESCRIPTION
Passing the `reindex` option in the constructor will re-initialize the index from scratch.

This is motivated by [this issue in `@comapeo/core`][0].

[0]: https://github.com/digidem/comapeo-core/issues/436