### PR TITLE
fix: make addCore() a no-op when closing/closed instead of throwing

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,12 +95,14 @@ class MultiCoreIndexer extends TypedEmitter {
    * Add a hypercore to the indexer. Must have the same value encoding as other
    * hypercores already in the indexer.
    *
-   * Rejects if called after the indexer is closed.
+   * No-op if called after the indexer is closing/closed: adding a core to a
+   * torn-down indexer is meaningless, and a late `add-core` event during
+   * teardown should not throw (mirrors `close()`'s own idempotency).
    *
    * @param {import('hypercore')<T, any>} core
    */
   addCore(core) {
-    this.#assertOpen('Cannot add core after closing')
+    if (!this.#isOpen()) return
     const coreIndexStream = new CoreIndexStream(
       core,
       this.#createStorage,

--- a/test/multi-core-indexer.test.js
+++ b/test/multi-core-indexer.test.js
@@ -154,6 +154,20 @@ test('State transitions', async () => {
   )
 })
 
+test('addCore() is a no-op after close (does not throw)', async () => {
+  const indexer = new MultiCoreIndexer([], {
+    batch: async () => {},
+    storage: () => new ram(),
+  })
+  await indexer.close()
+  const core = await create()
+  assert.doesNotThrow(
+    () => indexer.addCore(core),
+    'addCore after close should not throw'
+  )
+  assert.equal(indexer.state.current, 'closed', 'stays closed')
+})
+
 test('Calling idle() when already idle still resolves', async () => {
   const cores = await createMultiple(5)
   const expected = await generateFixtures(cores, 10)
@@ -648,7 +662,8 @@ test('closing causes many methods to fail', async (t) => {
     const closePromise = indexer.close()
     t.after(() => closePromise)
     const core = await create()
-    assert.throws(() => indexer.addCore(core))
+    // addCore is a no-op after close (a late add-core during teardown must not throw)
+    assert.doesNotThrow(() => indexer.addCore(core))
   }
 
   {


### PR DESCRIPTION
Fixes #48.

A late `add-core` event during teardown (a sync session / peer connection adding a core while the indexer is closing) called `addCore()` on a closed indexer, throwing **`Cannot add core after closing`** from inside a synchronous `EventEmitter` callback (uncaught). Adding a core to a torn-down indexer is meaningless, so this no-ops instead of throwing, mirroring `close()`'s own idempotency (`if (!this.#isOpen()) return`).

Downstream this prevented a storm of fatal frontend crashes in CoMapeo mobile (see digidem/comapeo-core#1277).

### Changes
- `addCore()` returns early when the indexer is closing/closed (was `#assertOpen('Cannot add core after closing')`); JSDoc updated.
- Updated the existing "closing causes many methods to fail" test (addCore no longer throws after close; `idle()` is unchanged) and added a focused no-op regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)