### PR TITLE
feat!: upgrade to hypercore 11

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,19 +14,20 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.17.1, 20.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -149,14 +149,15 @@ Type: `Hypercore`
 Add a hypercore to the indexer. Must have the same value encoding as other
 hypercores already in the indexer.
 
-Rejects if called after the indexer is closed.
+Throws if called after the indexer is closed or has errored.
 
 ### indexer.idle()
 
 Resolves when indexing state is `'idle'`.
 
-Resolves if the indexer is closed before this resolves. Rejects if called
-after the indexer is closed.
+Resolves if the indexer is cleanly closed before this resolves, and rejects
+with the pipeline error if the indexer errors first. Rejects if called after
+the indexer is closed or has errored.
 
 ### indexer.close()
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ batched) as fast as they can be read, up to `opts.maxBatch`. `block` is the
 block of data from the hypercore, `key` is the public key where the `block` is
 from, and `index` is the index of the `block` within the hypercore.
 
-**Note:** Currently if `batch` throws an error, things will break, and the
-entries will still be persisted as indexed. This will be fixed in a later
-release.
+**Note:** Delivery to `batch` is at-least-once: entries that were in an
+unfinished batch when the indexer was closed, or when an error occurred, are
+delivered again on the next start. `batch` must therefore be idempotent. If
+`batch` rejects, the indexer emits an `'error'` event and closes itself (see
+`indexer.on('error', handler)` below).
 
 #### opts.storage
 
@@ -161,7 +163,9 @@ after the indexer is closed.
 Stop the indexer and flush index state to storage. This will not close the
 underlying storage - it is up to the consumer to do that.
 
-No-op if called more than once.
+No-op if called more than once: returns the same promise as the first call.
+Also safe to call (and resolves) after the indexer has closed itself due to an
+error.
 
 ### indexer.unlink()
 
@@ -203,6 +207,20 @@ Event listener for when the indexer has completed indexing of available data.
 **Note**: During sync this can be emitted before sync is complete because the
 indexer has caught up with currently downloaded data, and the indexer will start
 indexing again as new data is downloaded.
+
+### indexer.on('error', handler)
+
+#### handler
+
+_Required_\
+Type: `(err: Error) => void`
+
+Emitted when the batch function rejects, a core read fails, or writing index
+state to storage fails. Errors are not recoverable within the instance: the
+indexer closes itself (pending `idle()` promises reject, `close()` still
+resolves), and indexing can be resumed by creating a new indexer with the same
+storage. As with any Node `EventEmitter`, if no `'error'` listener is attached
+the error is thrown as an uncaught exception.
 
 ## Maintainers
 

--- a/benchmarks/multi-core-indexer.js
+++ b/benchmarks/multi-core-indexer.js
@@ -2,10 +2,11 @@
 const MultiCoreIndexer = require('../')
 const nanobench = require('nanobench')
 const assert = require('assert')
-const ram = require('random-access-memory')
 const {
   generateFixtures,
   createMultiple,
+  createTempDir,
+  closeCreatedCores,
   throttledIdle,
 } = require('../test/helpers')
 
@@ -24,10 +25,12 @@ nanobench('Index 20 cores of 1000 blocks (10 times)', async (b) => {
         await new Promise((res) => setTimeout(res, 10))
       },
       maxBatch: 500,
-      storage: () => new ram(),
+      storage: createTempDir(),
     })
     await throttledIdle(indexer)
     assert(count === expected.length)
+    await indexer.close()
   }
   b.end()
+  await closeCreatedCores()
 })

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 // @ts-check
 const { Writable } = require('streamx')
 const { TypedEmitter } = require('tiny-typed-emitter')
-const { once } = require('events')
 const raf = require('random-access-file')
 const { CoreIndexStream } = require('./lib/core-index-stream')
 const { MultiCoreIndexStream } = require('./lib/multi-core-index-stream')
@@ -40,12 +39,19 @@ class MultiCoreIndexer extends TypedEmitter {
   #emitStateBound
   /** @type {import('./lib/utils.js').DeferredPromise | undefined} */
   #pendingIdle
+  /** @type {Promise<unknown>} */
+  #streamsClosed
+  /** @type {Promise<void> | undefined} */
+  #closePromise
 
   /**
    *
    * @param {import('hypercore')<T, any>[]} cores
    * @param {object} opts
-   * @param {(entries: Entry<T>[]) => Promise<void>} opts.batch
+   * @param {(entries: Entry<T>[]) => Promise<void>} opts.batch Called with
+   * entries to be indexed. Delivery is at-least-once: entries that were in an
+   * unfinished batch during an unclean close or error are delivered again on
+   * the next start, so this function must be idempotent.
    * @param {StorageParam} opts.storage
    * @param {boolean} [opts.reindex]
    * @param {number} [opts.maxBatch=100]
@@ -64,16 +70,32 @@ class MultiCoreIndexer extends TypedEmitter {
       highWaterMark: maxBatch,
     })
     this.#batch = batch
-    this.#writeStream = /** @type {Writable<Entry<T>>} */ (
-      new Writable({
-        writev: (entries, cb) => {
-          this.#handleEntries(entries).then(() => cb(), cb)
-        },
-        highWaterMark: maxBatch,
-        byteLength: () => 1,
-      })
-    )
+    this.#writeStream = new Writable({
+      writev: (entries, cb) => {
+        this.#handleEntries(/** @type {Entry<T>[]} */ (entries)).then(
+          () => cb(null),
+          cb
+        )
+      },
+      highWaterMark: maxBatch,
+      byteLength: () => 1,
+    })
     this.#indexStream.pipe(this.#writeStream)
+    // Capture 'close' promises before any error can destroy the streams, so
+    // that close() can await them even if the streams are already closed.
+    // (events.once() is not used because it rejects on 'error' events)
+    this.#streamsClosed = Promise.all(
+      [this.#indexStream, this.#writeStream].map(
+        (stream) => new Promise((res) => stream.once('close', () => res(null)))
+      )
+    )
+    // An error from the source streams (e.g. a core fails to read) or from
+    // the batch function (via writev) destroys the pipeline. Without these
+    // handlers that would throw an uncaught 'error' event and leave close()
+    // and idle() hanging forever.
+    const handleErrorBound = this.#handleError.bind(this)
+    this.#indexStream.on('error', handleErrorBound)
+    this.#writeStream.on('error', handleErrorBound)
     this.#emitStateBound = this.#emitState.bind(this)
     // This is needed because the source streams can start indexing before this
     // stream starts reading data. This ensures that the indexing state is
@@ -95,7 +117,7 @@ class MultiCoreIndexer extends TypedEmitter {
    * Add a hypercore to the indexer. Must have the same value encoding as other
    * hypercores already in the indexer.
    *
-   * Rejects if called after the indexer is closed.
+   * Throws if called after the indexer is closed.
    *
    * @param {import('hypercore')<T, any>} core
    */
@@ -128,21 +150,47 @@ class MultiCoreIndexer extends TypedEmitter {
    * Stop the indexer and flush index state to storage. This will not close the
    * underlying storage - it is up to the consumer to do that.
    *
-   * No-op if called more than once.
+   * No-op if called more than once: returns the same promise as the first call.
+   *
+   * @returns {Promise<void>}
    */
-  async close() {
-    if (!this.#isOpen()) return
+  close() {
+    this.#closePromise ??= this.#close()
+    return this.#closePromise
+  }
+
+  async #close() {
     this.#state = 'closing'
     this.#indexStream.off('indexing', this.#emitStateBound)
     this.#indexStream.off('drained', this.#emitStateBound)
     this.#writeStream.destroy()
     this.#indexStream.destroy()
-    await Promise.all([
-      once(this.#indexStream, 'close'),
-      once(this.#writeStream, 'close'),
-    ])
+    await this.#streamsClosed
     this.#pendingIdle?.resolve()
+    this.#pendingIdle = undefined
     this.#state = 'closed'
+  }
+
+  /**
+   * Called when the stream pipeline is destroyed by an error: from the batch
+   * function rejecting, or from a failure reading a core (e.g. a core closed
+   * while indexing). Emits 'error', rejects any pending idle() promises, and
+   * closes the indexer.
+   *
+   * @param {Error} err
+   */
+  #handleError(err) {
+    // Errors after close() has started are expected teardown noise, e.g.
+    // both streams in the pipeline erroring from the same root cause
+    if (!this.#isOpen()) return
+    const pendingIdle = this.#pendingIdle
+    this.#pendingIdle = undefined
+    this.close().catch(noop)
+    pendingIdle?.reject(err)
+    // Emit asynchronously: this runs inside streamx's destroy dispatch, and a
+    // throw from a missing 'error' listener in the destroy function would stop
+    // the stream from ever emitting 'close' and leave close() hanging.
+    queueMicrotask(() => this.emit('error', err))
   }
 
   /**
@@ -276,5 +324,8 @@ class MultiCoreIndexer extends TypedEmitter {
     }
   }
 }
+
+/* c8 ignore next: only called if close() rejects, which it never should */
+function noop() {}
 
 module.exports = MultiCoreIndexer

--- a/index.js
+++ b/index.js
@@ -181,13 +181,15 @@ class MultiCoreIndexer extends TypedEmitter {
    * @param {Error} err
    */
   #handleError(err) {
-    // If close() started before the pipeline began dying, the error raced a
-    // deliberate close (e.g. an in-flight batch rejecting). Emitting 'error'
-    // then would risk an uncaught exception in consumers that removed
+    // Should be unreachable: an error only reaches the pipe callback if a
+    // stream was destroyed with it before close() destroyed the streams
+    // (streamx ignores destroy(err) once destruction has started), and any
+    // such destroy sets #pipelineDyingBeforeClose via predestroy. Kept as a
+    // safety net: if a future streamx let an error race a deliberate close(),
+    // emitting it would risk an uncaught exception in consumers that removed
     // listeners after calling close(), and the at-least-once batch contract
-    // makes the error recoverable on next start, so it is deliberately
-    // ignored. If the pipeline was already dying when close() was called, the
-    // error preceded the close and is surfaced as normal.
+    // makes a swallowed error recoverable on next start.
+    /* c8 ignore next */
     if (this.#closeStarted() && !this.#pipelineDyingBeforeClose) return
     const pendingIdle = this.#pendingIdle
     this.#pendingIdle = undefined

--- a/index.js
+++ b/index.js
@@ -39,10 +39,11 @@ class MultiCoreIndexer extends TypedEmitter {
   #emitStateBound
   /** @type {import('./lib/utils.js').DeferredPromise | undefined} */
   #pendingIdle
-  /** @type {Promise<unknown>} */
+  /** @type {Promise<void>} */
   #streamsClosed
   /** @type {Promise<void> | undefined} */
   #closePromise
+  #pipelineDyingBeforeClose = false
 
   /**
    *
@@ -79,23 +80,22 @@ class MultiCoreIndexer extends TypedEmitter {
       },
       highWaterMark: maxBatch,
       byteLength: () => 1,
+      predestroy: () => this.#handlePipelineDying(),
     })
-    this.#indexStream.pipe(this.#writeStream)
-    // Capture 'close' promises before any error can destroy the streams, so
-    // that close() can await them even if the streams are already closed.
-    // (events.once() is not used because it rejects on 'error' events)
-    this.#streamsClosed = Promise.all(
-      [this.#indexStream, this.#writeStream].map(
-        (stream) => new Promise((res) => stream.once('close', () => res(null)))
-      )
-    )
-    // An error from the source streams (e.g. a core fails to read) or from
-    // the batch function (via writev) destroys the pipeline. Without these
-    // handlers that would throw an uncaught 'error' event and leave close()
-    // and idle() hanging forever.
-    const handleErrorBound = this.#handleError.bind(this)
-    this.#indexStream.on('error', handleErrorBound)
-    this.#writeStream.on('error', handleErrorBound)
+    // The pipe callback fires exactly once, after both streams have closed:
+    // with null after a clean teardown (destroyed by close()), or with the
+    // root-cause error if anything failed (e.g. a core fails to read, or the
+    // batch function rejects via writev).
+    this.#streamsClosed = new Promise((resolve) => {
+      this.#indexStream.pipe(this.#writeStream, (err) => {
+        resolve()
+        if (err) this.#handleError(err)
+      })
+    })
+    // 'destroying' fires synchronously the moment the index stream or any of
+    // its source streams starts destroying - 'error' and the pipe callback
+    // only fire after teardown completes
+    this.#indexStream.on('destroying', () => this.#handlePipelineDying())
     this.#emitStateBound = this.#emitState.bind(this)
     // This is needed because the source streams can start indexing before this
     // stream starts reading data. This ensures that the indexing state is
@@ -122,7 +122,7 @@ class MultiCoreIndexer extends TypedEmitter {
    * @param {import('hypercore')<T, any>} core
    */
   addCore(core) {
-    this.#assertOpen('Cannot add core after closing')
+    this.#assertUsable('Cannot add core after closing')
     const coreIndexStream = new CoreIndexStream(
       core,
       this.#createStorage,
@@ -134,11 +134,12 @@ class MultiCoreIndexer extends TypedEmitter {
   /**
    * Resolves when indexing state is 'idle'.
    *
-   * Resolves if the indexer is closed before this resolves. Rejects if called
-   * after the indexer is closed.
+   * Resolves if the indexer is cleanly closed before this resolves. Rejects
+   * with the pipeline error if the indexer errors first, and rejects if
+   * called after the indexer is closed.
    */
   async idle() {
-    this.#assertOpen('Cannot await idle after closing')
+    this.#assertUsable('Cannot await idle after closing')
     if (this.#getState().current === 'idle') return
     if (!this.#pendingIdle) {
       this.#pendingIdle = pDefer()
@@ -180,16 +181,20 @@ class MultiCoreIndexer extends TypedEmitter {
    * @param {Error} err
    */
   #handleError(err) {
-    // Errors after close() has started are expected teardown noise, e.g.
-    // both streams in the pipeline erroring from the same root cause
-    if (!this.#isOpen()) return
+    // If close() started before the pipeline began dying, the error raced a
+    // deliberate close (e.g. an in-flight batch rejecting). Emitting 'error'
+    // then would risk an uncaught exception in consumers that removed
+    // listeners after calling close(), and the at-least-once batch contract
+    // makes the error recoverable on next start, so it is deliberately
+    // ignored. If the pipeline was already dying when close() was called, the
+    // error preceded the close and is surfaced as normal.
+    if (this.#closeStarted() && !this.#pipelineDyingBeforeClose) return
     const pendingIdle = this.#pendingIdle
     this.#pendingIdle = undefined
     this.close().catch(noop)
     pendingIdle?.reject(err)
     // Emit asynchronously: this runs inside streamx's destroy dispatch, and a
-    // throw from a missing 'error' listener in the destroy function would stop
-    // the stream from ever emitting 'close' and leave close() hanging.
+    // throw from a consumer's 'error' listener there would break teardown.
     queueMicrotask(() => this.emit('error', err))
   }
 
@@ -212,24 +217,49 @@ class MultiCoreIndexer extends TypedEmitter {
     }
   }
 
-  /** @returns {boolean} */
-  #isOpen() {
+  /**
+   * Whether close() has been called, by the consumer or from #handleError.
+   * Deliberately blind to pipeline death that close() has not reacted to yet:
+   * that distinction is what #handleError's swallow-or-emit decision needs.
+   *
+   * @returns {boolean}
+   */
+  #closeStarted() {
     switch (this.#state) {
       case 'idle':
       case 'indexing':
-        return true
+        return false
       case 'closing':
       case 'closed':
-        return false
+        return true
       /* c8 ignore next 2 */
       default:
         throw new ExhaustivenessError(this.#state)
     }
   }
 
-  /** @param {string} message */
-  #assertOpen(message) {
-    if (!this.#isOpen()) throw new Error(message)
+  /**
+   * Throws unless the indexer is still usable: close() not started and the
+   * pipeline not dying from an error that has not yet reached #handleError.
+   *
+   * @param {string} message
+   */
+  #assertUsable(message) {
+    if (this.#closeStarted() || this.#pipelineDyingBeforeClose) {
+      throw new Error(message)
+    }
+  }
+
+  /**
+   * Called synchronously (via the streams' predestroy hooks) the moment
+   * anything in the pipeline starts destroying. Ignores the destroys issued
+   * by #close itself, so #pipelineDying is only ever set by pipeline death
+   * that no close() had reacted to - which is exactly what #handleError's
+   * swallow-or-emit decision and #assertUsable need to know.
+   */
+  #handlePipelineDying() {
+    if (this.#closeStarted()) return
+    this.#pipelineDyingBeforeClose = true
   }
 
   /** @param {Entry<T>[]} entries */

--- a/lib/bitfield.js
+++ b/lib/bitfield.js
@@ -32,11 +32,7 @@ class FixedBitfield {
 
     if (val === ((v & (1 << j)) !== 0)) return false
 
-    const u = val ? v | (1 << j) : v ^ (1 << j)
-
-    if (u === v) return false
-
-    this.bitfield[i] = u
+    this.bitfield[i] = val ? v | (1 << j) : v ^ (1 << j)
     return true
   }
 }
@@ -101,17 +97,6 @@ class Bitfield {
 
     p.dirty = true
     this.unflushed?.push(p)
-  }
-
-  /** @returns {Promise<void>} */
-  close() {
-    return new Promise((resolve, reject) => {
-      if (!this.storage) return resolve()
-      this.storage.close((err) => {
-        if (err) reject(err)
-        else resolve()
-      })
-    })
   }
 
   /** @returns {Promise<void>} */

--- a/lib/bitfield.js
+++ b/lib/bitfield.js
@@ -4,7 +4,6 @@
 const BigSparseArray = require('big-sparse-array')
 const b4a = require('b4a')
 
-/* c8 ignore start */
 class FixedBitfield {
   /**
    * @param {number} index
@@ -41,9 +40,7 @@ class FixedBitfield {
     return true
   }
 }
-/* c8 ignore stop */
 
-/* c8 ignore start */
 class Bitfield {
   /**
    *
@@ -123,12 +120,17 @@ class Bitfield {
       if (!this.storage) return resolve()
       if (!this.unflushed?.length) return resolve()
 
+      // Swap in a new array before the async writes below: pages that become
+      // dirty while a write is in flight are re-added to the new array, so
+      // that they are written by the next flush rather than lost
+      const flushing = this.unflushed
+      this.unflushed = []
       const self = this
-      let missing = this.unflushed.length
+      let missing = flushing.length
       /** @type {Error | null} */
       let error = null
 
-      for (const page of this.unflushed) {
+      for (const page of flushing) {
         const buf = b4a.from(
           page.bitfield.buffer,
           page.bitfield.byteOffset,
@@ -142,8 +144,17 @@ class Bitfield {
       function done(err) {
         if (err) error = err
         if (--missing) return
-        if (error) return reject(error)
-        self.unflushed = []
+        if (error) {
+          // Re-queue the flushed pages so that the next flush retries them
+          // (pages re-dirtied while the writes were in flight are already
+          // back in unflushed, so skip those)
+          for (const page of flushing) {
+            if (page.dirty) continue
+            page.dirty = true
+            self.unflushed?.push(page)
+          }
+          return reject(error)
+        }
         resolve()
       }
     })
@@ -167,7 +178,6 @@ class Bitfield {
     })
   }
 }
-/* c8 ignore stop */
 
 module.exports = Bitfield
 

--- a/lib/core-index-stream.js
+++ b/lib/core-index-stream.js
@@ -20,11 +20,12 @@ const { promisify } = require('node:util')
  * 5. Store index state and continue indexing from the previous state
  *
  * @template {ValueEncoding} [T='binary']
- * @extends {Readable<Entry<T>, Entry<T>, Entry<T>, true, false, import('./types').IndexStreamEvents<Entry<T>>>}
+ * @extends {Readable<import('./types').IndexStreamEvents>}
  */
 class CoreIndexStream extends Readable {
   #handleAppendBound
   #handleDownloadBound
+  #handleCoreCloseBound
   /** @type {Bitfield | undefined} */
   #indexedBitfield
   /** @type {Bitfield | undefined} */
@@ -41,6 +42,7 @@ class CoreIndexStream extends Readable {
   #readBufferAvailable = true
   #destroying = false
   #drained = false
+  #coreClosed = false
 
   /**
    * @param {import('hypercore')<T, any>} core
@@ -58,6 +60,7 @@ class CoreIndexStream extends Readable {
     this.#core = core
     this.#handleAppendBound = this.#handleAppend.bind(this)
     this.#handleDownloadBound = this.#handleDownload.bind(this)
+    this.#handleCoreCloseBound = this.#handleCoreClose.bind(this)
     this.#createStorage = async () => {
       await this.#core.ready()
 
@@ -73,8 +76,16 @@ class CoreIndexStream extends Readable {
   }
 
   get remaining() {
+    // After the core is closed its length is reported as 0, so only blocks
+    // already read but not yet indexed count as remaining
+    if (this.#coreClosed) return this.#inProgress
     return (
-      this.#core.length - this.#index + this.#downloaded.size + this.#inProgress
+      // core.close() drops core.length to 0 synchronously, before the async
+      // 'close' handler sets #coreClosed, so this difference must be clamped
+      // or `remaining` would go negative in that window
+      Math.max(0, this.#core.length - this.#index) +
+      this.#downloaded.size +
+      this.#inProgress
     )
   }
 
@@ -125,6 +136,7 @@ class CoreIndexStream extends Readable {
   async #destroy() {
     this.#core.removeListener('append', this.#handleAppendBound)
     this.#core.removeListener('download', this.#handleDownloadBound)
+    this.#core.removeListener('close', this.#handleCoreCloseBound)
     await this.#indexedBitfield?.flush()
     if (this.#storage) await closeStorage(this.#storage)
   }
@@ -137,6 +149,12 @@ class CoreIndexStream extends Readable {
     this.#inProgressBitfield = await new Bitfield()
     this.#core.on('append', this.#handleAppendBound)
     this.#core.on('download', this.#handleDownloadBound)
+    // If the core is closed while this stream is still indexing it, there is
+    // nothing more that can be indexed: without this the stream would wait
+    // forever (a closed core reports length 0) with `remaining` inaccurate.
+    // Any unindexed blocks are picked up by a future indexer from the index
+    // state persisted in the bitfield, once the core is re-opened.
+    this.#core.once('close', this.#handleCoreCloseBound)
   }
 
   async #read() {
@@ -146,14 +164,24 @@ class CoreIndexStream extends Readable {
       // If nothing is left to index, wait for new data
       await (this.#pending = pDefer()).promise
     }
+    // A closed core has nothing more that can be indexed ('drained' was
+    // already emitted above, since a closed core reports length 0): keep
+    // waiting (only destroying the stream ends this) rather than emitting a
+    // spurious 'indexing' event below
+    while (this.#coreClosed && !this.#destroying) {
+      await (this.#pending = pDefer()).promise
+    }
+    if (this.#coreClosed) return
     this.#drained = false
     this.emit('indexing')
     let didPush = false
     this.#readBufferAvailable = true
     while (this.#readBufferAvailable && this.#index < this.#core.length) {
-      didPush = (await this.#pushEntry(this.#index)) || didPush
-      // Don't increment this until after the async push above
-      this.#index++
+      // Increment before the (async) push: newer streamx emits 'data'
+      // synchronously from push(), and `remaining` must not count the pushed
+      // entry via both `#index` and `#inProgress` when listeners run
+      const index = this.#index++
+      didPush = (await this.#pushEntry(index)) || didPush
     }
     // Still space in the read buffer? Process any downloaded blocks
     if (this.#readBufferAvailable) {
@@ -190,10 +218,33 @@ class CoreIndexStream extends Readable {
     const isProcessed =
       this.#indexedBitfield?.get(index) || this.#inProgressBitfield?.get(index)
     if (isProcessed) return false
-    const block = await this.#core.get(index, { wait: false })
-    if (block === null) return false
-    this.#inProgressBitfield?.set(index, true)
+    // Count this block as in-progress before the async read, so that
+    // `remaining` stays accurate while the read is in flight
     this.#inProgress++
+    /** @type {Entry<T>['block'] | null} */
+    let block
+    try {
+      block = await this.#core.get(index, { wait: false })
+    } catch (err) {
+      // Reads rejected because the core was closed while they were in
+      // flight: skip these blocks, like other blocks of a closed core.
+      // The intersection type adds `closing`/`closed`, which exist on
+      // hypercore 11 but are missing from the vendored hypercore types.
+      const core =
+        /** @type {import('hypercore')<T, any> & { closing?: Promise<void> | null, closed?: boolean }} */ (
+          this.#core
+        )
+      if (core.closing || core.closed) {
+        this.#inProgress--
+        return false
+      }
+      throw err
+    }
+    if (block === null) {
+      this.#inProgress--
+      return false
+    }
+    this.#inProgressBitfield?.set(index, true)
     /* c8 ignore next: this should always be set at this point */
     if (!this.#core.key) throw new Error('Missing core key')
     const entry = { key: this.#core.key, block, index }
@@ -203,6 +254,18 @@ class CoreIndexStream extends Readable {
 
   async #handleAppend() {
     this.#pending.resolve()
+  }
+
+  #handleCoreClose() {
+    this.#coreClosed = true
+    this.#downloaded.clear()
+    // Wake a #read that is waiting for new data so it re-checks state
+    this.#pending.resolve()
+    // If the stream was already drained when the core closed, a parked #read
+    // will not re-emit 'drained', but `remaining` has now changed (dropped to
+    // in-progress only): re-emit so state listeners re-read it, otherwise a
+    // pending idle() would never resolve
+    if (this.#drained) this.emit('drained')
   }
 
   /**

--- a/lib/core-index-stream.js
+++ b/lib/core-index-stream.js
@@ -110,6 +110,7 @@ class CoreIndexStream extends Readable {
   _predestroy() {
     this.#destroying = true
     this.#pending.resolve()
+    this.emit('destroying')
   }
 
   /** @param {any} cb */

--- a/lib/multi-core-index-stream.js
+++ b/lib/multi-core-index-stream.js
@@ -1,7 +1,6 @@
 // @ts-check
 const { Readable } = require('streamx')
 const { pDefer } = require('./utils')
-const { once } = require('events')
 
 /** @typedef {import('./types').ValueEncoding} ValueEncoding */
 /** @typedef {import('./types').JSONValue} JSONValue */
@@ -16,12 +15,13 @@ const { once } = require('events')
 
 /**
  * @template {ValueEncoding} [T='binary']
- * @extends {Readable<Entry<T>, Entry<T>, Entry<T>, true, false, import('./types').IndexStreamEvents<Entry<T>>>}
+ * @extends {Readable<import('./types').IndexStreamEvents>}
  */
 class MultiCoreIndexStream extends Readable {
   #handleIndexingBound
   #handleDrainedBound
-  /** @type {Map<CoreIndexStream<T>, () => void>} */
+  #handleStreamErrorBound
+  /** @type {Map<CoreIndexStream<T>, { handleReadableFn: () => void, closePromise: Promise<unknown> }>} */
   #streams = new Map()
   /** @type {Map<string, CoreIndexStream<T>>} */
   #streamsById = new Map()
@@ -48,6 +48,7 @@ class MultiCoreIndexStream extends Readable {
     this.#drained = streams.length === 0
     this.#handleIndexingBound = this.#handleIndexing.bind(this)
     this.#handleDrainedBound = this.#handleDrained.bind(this)
+    this.#handleStreamErrorBound = this.#handleStreamError.bind(this)
     for (const s of streams) {
       this.addStream(s)
     }
@@ -87,7 +88,13 @@ class MultiCoreIndexStream extends Readable {
     this.#drained = false
     // Do this so that we can remove this listener when we destroy the stream
     const handleReadableFn = this.#handleReadable.bind(this, stream)
-    this.#streams.set(stream, handleReadableFn)
+    // Capture the 'close' promise now: if the stream is destroyed by an
+    // error before #destroy runs, waiting for 'close' there would hang.
+    // (events.once() is not used because it rejects on 'error' events)
+    const closePromise = new Promise((res) =>
+      stream.once('close', () => res(null))
+    )
+    this.#streams.set(stream, { handleReadableFn, closePromise })
     stream.core
       .ready()
       .then(() => {
@@ -101,6 +108,10 @@ class MultiCoreIndexStream extends Readable {
     stream.on('readable', handleReadableFn)
     stream.on('indexing', this.#handleIndexingBound)
     stream.on('drained', this.#handleDrainedBound)
+    // Forward source stream errors (e.g. a core that fails to read because it
+    // was closed while indexing), otherwise this stream would wait forever
+    // for the errored source and the error would be an uncaught exception
+    stream.on('error', this.#handleStreamErrorBound)
   }
 
   /**
@@ -137,12 +148,16 @@ class MultiCoreIndexStream extends Readable {
 
   async #destroy() {
     const closePromises = []
-    for (const [stream, handleReadableFn] of this.#streams) {
+    for (const [stream, { handleReadableFn, closePromise }] of this.#streams) {
       stream.off('readable', handleReadableFn)
       stream.off('indexing', this.#handleIndexingBound)
       stream.off('drained', this.#handleDrainedBound)
+      stream.off('error', this.#handleStreamErrorBound)
+      // Swallow errors from a stream that fails while being destroyed - the
+      // error that destroyed this stream (if any) has already been emitted
+      stream.on('error', noop)
       stream.destroy()
-      closePromises.push(once(stream, 'close'))
+      closePromises.push(closePromise)
     }
     await Promise.all(closePromises)
   }
@@ -173,6 +188,13 @@ class MultiCoreIndexStream extends Readable {
   #handleReadable(stream) {
     this.#readable.add(stream)
     this.#pending.resolve()
+  }
+
+  /** @param {Error} err */
+  #handleStreamError(err) {
+    // Errors from sources already being destroyed
+    if (this.#destroying) return
+    this.destroy(err)
   }
 
   // Whenever a source stream emits an indexing event, bubble it up so that the

--- a/lib/multi-core-index-stream.js
+++ b/lib/multi-core-index-stream.js
@@ -21,6 +21,7 @@ class MultiCoreIndexStream extends Readable {
   #handleIndexingBound
   #handleDrainedBound
   #handleStreamErrorBound
+  #emitDestroyingBound
   /** @type {Map<CoreIndexStream<T>, { handleReadableFn: () => void, closePromise: Promise<unknown> }>} */
   #streams = new Map()
   /** @type {Map<string, CoreIndexStream<T>>} */
@@ -29,6 +30,7 @@ class MultiCoreIndexStream extends Readable {
   #readable = new Set()
   #pending = pDefer()
   #destroying = false
+  #emittedDestroying = false
   // We cache drained state here rather than reading all streams every time
   #drained
 
@@ -49,6 +51,7 @@ class MultiCoreIndexStream extends Readable {
     this.#handleIndexingBound = this.#handleIndexing.bind(this)
     this.#handleDrainedBound = this.#handleDrained.bind(this)
     this.#handleStreamErrorBound = this.#handleStreamError.bind(this)
+    this.#emitDestroyingBound = this.#emitDestroying.bind(this)
     for (const s of streams) {
       this.addStream(s)
     }
@@ -84,6 +87,9 @@ class MultiCoreIndexStream extends Readable {
    * @param {CoreIndexStream<T>} stream
    */
   addStream(stream) {
+    // A stream added after #destroy's loop has run would never be destroyed,
+    // leaking its storage handle and core listeners
+    if (this.destroying) throw new Error('Cannot add stream after destroy')
     if (this.#streams.has(stream)) return
     this.#drained = false
     // Do this so that we can remove this listener when we destroy the stream
@@ -112,6 +118,9 @@ class MultiCoreIndexStream extends Readable {
     // was closed while indexing), otherwise this stream would wait forever
     // for the errored source and the error would be an uncaught exception
     stream.on('error', this.#handleStreamErrorBound)
+    // Forward synchronously so consumers learn a source is dying before its
+    // teardown completes - its 'error' event only fires afterwards
+    stream.on('destroying', this.#emitDestroyingBound)
   }
 
   /**
@@ -139,6 +148,7 @@ class MultiCoreIndexStream extends Readable {
   _predestroy() {
     this.#destroying = true
     this.#pending.resolve()
+    this.#emitDestroying()
   }
 
   /** @param {any} cb */
@@ -153,6 +163,7 @@ class MultiCoreIndexStream extends Readable {
       stream.off('indexing', this.#handleIndexingBound)
       stream.off('drained', this.#handleDrainedBound)
       stream.off('error', this.#handleStreamErrorBound)
+      stream.off('destroying', this.#emitDestroyingBound)
       // Swallow errors from a stream that fails while being destroyed - the
       // error that destroyed this stream (if any) has already been emitted
       stream.on('error', noop)
@@ -195,6 +206,13 @@ class MultiCoreIndexStream extends Readable {
     // Errors from sources already being destroyed
     if (this.#destroying) return
     this.destroy(err)
+  }
+
+  // Emitted at most once, from own _predestroy or forwarded from a source
+  #emitDestroying() {
+    if (this.#emittedDestroying) return
+    this.#emittedDestroying = true
+    this.emit('destroying')
   }
 
   // Whenever a source stream emits an indexing event, bubble it up so that the

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,11 @@ import { ReadableEvents } from 'streamx'
 
 export type IndexStateCurrent = 'idle' | 'indexing' | 'closing' | 'closed'
 
+export interface IndexStreamEvents extends ReadableEvents {
+  drained: []
+  indexing: []
+}
+
 export interface IndexState {
   current: IndexStateCurrent
   remaining: number
@@ -17,11 +22,7 @@ export interface IndexEvents {
   'index-state': (state: IndexState) => void
   indexing: () => void
   idle: () => void
-}
-
-export type IndexStreamEvents<T> = ReadableEvents<T> & {
-  drained: () => void
-  indexing: () => void
+  error: (err: Error) => void
 }
 
 export type ValueEncoding = 'binary' | 'utf-8' | 'json'

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,13 @@ export type IndexStateCurrent = 'idle' | 'indexing' | 'closing' | 'closed'
 export interface IndexStreamEvents extends ReadableEvents {
   drained: []
   indexing: []
+  /**
+   * Emitted synchronously when the stream (or, for MultiCoreIndexStream, any
+   * of its source streams) starts destroying. Unlike 'error' and 'close',
+   * which only fire after teardown completes, this fires the moment
+   * destruction is initiated.
+   */
+  destroying: []
 }
 
 export interface IndexState {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,23 +9,22 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^18.16.19",
-        "@types/streamx": "^2.9.1",
         "b4a": "^1.6.4",
         "big-sparse-array": "^1.0.2",
         "random-access-file": "^4.0.4",
-        "streamx": "^2.15.0",
+        "streamx": "^2.28.0",
         "tiny-typed-emitter": "^2.1.0"
       },
       "devDependencies": {
         "@digidem/types": "^1.0.1",
         "@types/nanobench": "^3.0.0",
+        "@types/node": "^18.19.130",
         "@types/sodium-native": "^2.3.5",
         "borp": "^0.9.1",
         "c8": "^9.1.0",
         "eslint": "^8.44.0",
         "husky": "^8.0.3",
-        "hypercore": "^10.17.0",
+        "hypercore": "^11.35.0",
         "lint-staged": "^13.2.3",
         "multifeed": "^6.0.0",
         "multifeed-index": "^3.4.2",
@@ -36,7 +35,10 @@
         "random-access-memory": "^6.2.0",
         "sodium-native": "^4.0.4",
         "tempy": "^3.0.0",
-        "typescript": "^5.1.6"
+        "typescript": "~5.8.3"
+      },
+      "peerDependencies": {
+        "hypercore": "^11.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -454,9 +456,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
-      "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA=="
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/sodium-native": {
       "version": "2.3.5",
@@ -471,6 +478,7 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@types/streamx/-/streamx-2.9.1.tgz",
       "integrity": "sha512-9bywzhouyedmci7WCIPFwJ8zASDnxt2gaVUy52X0p0Tt085IJSAEP0L6j4SSNeDMSLzpYu6cPz0GrJZ7kPJ6Bg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -631,15 +639,204 @@
       "dev": true
     },
     "node_modules/b4a": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
-      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz",
+      "integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-ansi-escapes": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-ansi-escapes/-/bare-ansi-escapes-2.2.3.tgz",
+      "integrity": "sha512-02ES4/E2RbrtZSnHJ9LntBhYkLA6lPpSEeP8iqS3MccBIVhVBlEmruF1I7HZqx5Q8aiTeYfQVeqmrU9YO2yYoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-stream": "^2.6.5"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-assert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bare-assert/-/bare-assert-1.2.0.tgz",
+      "integrity": "sha512-c6uvgvTJBspTDxtVnPgrBKmLgcpW3Fp72NVKDLg6oT4QjQbhGtvrkHMhGYMK1sh4vjBHOBmuUalyt9hSzV37fQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-inspect": "^3.1.2"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-inspect": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/bare-inspect/-/bare-inspect-3.1.4.tgz",
+      "integrity": "sha512-jfW5KRA84o3REpI6Vr4nbvMn+hqVAw8GU1mMdRwUsY5yJovQamxYeKGVKGqdzs+8ZbG4jRzGUXP/3Ji/DnqfPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-ansi-escapes": "^2.1.0",
+        "bare-type": "^1.0.0"
+      },
+      "engines": {
+        "bare": ">=1.18.0"
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
+      "integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-semver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
+      "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-type/-/bare-type-1.1.0.tgz",
+      "integrity": "sha512-LdtnnEEYldOc87Dr4GpsKnStStZk3zfgoEMXy8yvEZkXrcCv9RtYDrUYWFsBQHtaB0s1EUWmcvS6XmEZYIj3Bw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.2.0"
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/big-sparse-array": {
       "version": "1.0.3",
@@ -1277,10 +1474,11 @@
       }
     },
     "node_modules/compact-encoding": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-2.11.0.tgz",
-      "integrity": "sha512-CRfTuyy9Tg7EwxNKvIq3yFIr2JnJLyVr9Yj234VsDCL59hdXcZH3TdzY/2kwbAqVogIoRBJjnNKCEnXbxTIEeg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.3.0.tgz",
+      "integrity": "sha512-e64XyzlBvTRJ3iScuU/U2w25Dglkm7fhrRbrGaHIwuTlNnzjRKMaQBCVl7mJRvZg7wI5a9wX1IVTXCuaAANNkw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.3.0"
       }
@@ -1302,15 +1500,6 @@
       "resolved": "https://registry.npmjs.org/count-trailing-zeros/-/count-trailing-zeros-1.0.1.tgz",
       "integrity": "sha1-q6bFgzvkENRbHso+bVg4RM5oLHc=",
       "dev": true
-    },
-    "node_modules/crc-universal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/crc-universal/-/crc-universal-1.0.2.tgz",
-      "integrity": "sha512-RrQ/8bT3WKNsGQuHWV3wf3Y0SUJTa8GADrkrQ1gsDljJLs8h/ENJRFUkL3z1TRWas80gv3Kdo6z1IPYyVJ/sxQ==",
-      "dev": true,
-      "dependencies": {
-        "node-gyp-build": "^4.5.0"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1386,6 +1575,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/device-file": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/device-file/-/device-file-2.3.1.tgz",
+      "integrity": "sha512-bmON44lwxJPle9N2OcH4tqM44pMGZKT8G6OkzXkz0urvqQ9LKkoQdTS6w0ztYfmLdUE27R4UUmx0+y2gEz4Jug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.7",
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0",
+        "fd-lock": "^2.1.0",
+        "fs-native-extensions": "^1.4.0",
+        "ready-resource": "^1.2.0"
       }
     },
     "node_modules/doctrine": {
@@ -1850,6 +2054,15 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -1889,9 +2102,10 @@
       "dev": true
     },
     "node_modules/fast-fifo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
-      "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -1912,6 +2126,19 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-lock": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fd-lock/-/fd-lock-2.2.0.tgz",
+      "integrity": "sha512-Il4jWBhjjgvUg+z8d0bC7ncXqB42caqKTUpnZ9jpcqiPmw8bkIixt7Kic1czbZPMxAQD/9kEqfZ5Dq77nSll0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.0",
+        "fs-native-extensions": "^1.4.4",
+        "ready-resource": "^1.2.0",
+        "resource-on-exit": "^1.0.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -1965,10 +2192,11 @@
       }
     },
     "node_modules/flat-tree": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/flat-tree/-/flat-tree-1.9.0.tgz",
-      "integrity": "sha512-WRu5/q9fcdL9f7L6Ahq8fR153e5Zr5aU6plPHupN6JDWuvEJbMjrEQprge3/I7ytndHC6/GUNg5Rg8XEisuv5w==",
-      "dev": true
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/flat-tree/-/flat-tree-1.13.0.tgz",
+      "integrity": "sha512-fT3HIuCPwHhFgJ20QYzDHgUG0zMmFg5cHvFiFo5h+QMSJ28TihsEVY0f8HGliuO+pOzmvjMx1odToeaEWkTnyQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/flatted": {
       "version": "3.2.5",
@@ -2005,15 +2233,14 @@
       }
     },
     "node_modules/fs-native-extensions": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/fs-native-extensions/-/fs-native-extensions-1.2.2.tgz",
-      "integrity": "sha512-zpW4FsykyuKQqVIeXxi9J+6lPgg4PPyuegKS5nMSkb6oRwBsQga7wczKqi8vSjJ7K0TmNdQrCdF/7hOtjCqrpQ==",
-      "hasInstallScript": true,
-      "optional": true,
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/fs-native-extensions/-/fs-native-extensions-1.5.0.tgz",
+      "integrity": "sha512-nuZLFm9mGCxvyi7Llww/J4OyifKCS21nEUTAmnlTZp3FObPOvA32aCedCmt4Z+8yk+caqfClNaSCfn/P7T7FLQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "napi-macros": "^2.0.0",
-        "node-gyp-build": "^4.2.3",
-        "uv-errors": "^1.0.1"
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -2039,6 +2266,23 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "node_modules/generate-object-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-2.0.0.tgz",
+      "integrity": "sha512-KwuURPyqn2Mz8DdV29pJwQu0Y7tcsbkULr82eeOcY/ZllFK6I9Wm8dsRByIu7CKWlFi9BdW1b3mcXMp/kQBQsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "node_modules/generate-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/generate-string/-/generate-string-1.0.1.tgz",
+      "integrity": "sha512-IfTY0dKZM43ACyGvXkbG7De7WY7MxTS5VO6Juhe8oJKpCmrYYXoqp/cJMskkpi0k9H8wuXq0H+eI898/BCqvXg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -2247,28 +2491,32 @@
       }
     },
     "node_modules/hypercore": {
-      "version": "10.17.0",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-10.17.0.tgz",
-      "integrity": "sha512-Yp9lyfUjp81Gy1nPHemNFtYQtngliCGZ6prH+qxvjr2FPVG1QFtNqtOh+ZxFu4hXZ1dAOLYkQOA7Qq2vjFe64A==",
+      "version": "11.35.0",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-11.35.0.tgz",
+      "integrity": "sha512-ixba6oHaK2XXmv7nERLz7T6DUb9rsPc7OAMgG3wVbFELcX7x0RZkjUaupjgDEuK1VbiiNrH784+v95J9VdCC7w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@hyperswarm/secret-stream": "^6.0.0",
         "b4a": "^1.1.0",
+        "bare-events": "^2.2.0",
         "big-sparse-array": "^1.0.3",
-        "compact-encoding": "^2.11.0",
-        "crc-universal": "^1.0.2",
-        "events": "^3.3.0",
+        "compact-encoding": "^3.0.0",
+        "fast-fifo": "^1.3.0",
         "flat-tree": "^1.9.0",
         "hypercore-crypto": "^3.2.1",
+        "hypercore-errors": "^1.5.0",
+        "hypercore-id-encoding": "^1.2.0",
+        "hypercore-storage": "^3.2.0",
         "is-options": "^1.0.1",
-        "protomux": "^3.4.0",
-        "quickbit-universal": "^2.1.1",
-        "random-access-file": "^4.0.0",
+        "nanoassert": "^2.0.0",
+        "protomux": "^3.5.0",
+        "quickbit-universal": "^2.2.0",
         "random-array-iterator": "^1.0.0",
         "safety-catch": "^1.0.1",
-        "sodium-universal": "^4.0.0",
+        "sodium-universal": "^5.0.1",
         "streamx": "^2.12.4",
-        "xache": "^1.1.0",
+        "unslab": "^1.3.0",
         "z32": "^1.0.0"
       }
     },
@@ -2279,31 +2527,48 @@
       "dev": true
     },
     "node_modules/hypercore-crypto": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-3.4.0.tgz",
-      "integrity": "sha512-0cZA1B58p1J84TDbTh8DMMIj7Qr7Rzz8NyGIo+ykUhdwD21gtjiiLWoME92QvN+lgbfu0Zfr9vwxT8sRmyg+AA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-3.7.0.tgz",
+      "integrity": "sha512-SWxobptQf2V/+ZLCCDRTXqFzGfTPIkNIuDyLKXpEMfcpJ1/ec94N9aWgylHcWOHmRt14ng/KR7z0BugebWHK9Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "b4a": "^1.1.0",
-        "compact-encoding": "^2.5.1",
-        "sodium-universal": "^4.0.0"
+        "b4a": "^1.6.6",
+        "compact-encoding": "^3.0.0",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/hypercore-crypto/node_modules/sodium-native": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.1.0.tgz",
+      "integrity": "sha512-3RxgyWyJlhTsABPnJVpCI5CoTDANZTqqFrEPqr+kjfnRaBihpVtMUE3yTF40ukdoB1APXeoBNKF3MzZAIHg39g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bare-assert": "^1.2.0",
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.1"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
       }
     },
     "node_modules/hypercore-crypto/node_modules/sodium-universal": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.0.tgz",
-      "integrity": "sha512-iKHl8XnBV96k1c75gwwzANFdephw/MDWSjQAjPmBE+du0y3P23Q8uf7AcdcfFsYAMwLg7WVBfSAIBtV/JvRsjA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-5.0.1.tgz",
+      "integrity": "sha512-rv+aH+tnKB5H0MAc2UadHShLMslpJsc4wjdnHRtiSIEYpOetCgu8MS4ExQRia+GL/MK3uuCyZPeEsi+J3h+Q+Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "blake2b": "^2.1.1",
-        "chacha20-universal": "^1.0.4",
-        "nanoassert": "^2.0.0",
-        "sha256-universal": "^1.1.0",
-        "sha512-universal": "^1.1.0",
-        "siphash24": "^1.0.1",
-        "sodium-javascript": "~0.8.0",
-        "sodium-native": "^4.0.0",
-        "xsalsa20": "^1.0.0"
+        "sodium-native": "^5.0.1"
+      },
+      "peerDependencies": {
+        "sodium-javascript": "~0.8.0"
+      },
+      "peerDependenciesMeta": {
+        "sodium-javascript": {
+          "optional": true
+        }
       }
     },
     "node_modules/hypercore-default-storage": {
@@ -2326,6 +2591,27 @@
       "dependencies": {
         "mkdirp-classic": "^0.5.2",
         "random-access-storage": "^1.1.1"
+      }
+    },
+    "node_modules/hypercore-errors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hypercore-errors/-/hypercore-errors-1.5.0.tgz",
+      "integrity": "sha512-5KQ/SuDxsvet+7qWA35Ay6zdD9WyAHQoyWHGcPUTbmJBd300gvNIJoi3oma7kp4TTCSzii6qYumNZe/s0j/saQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hypercore-id-encoding": "^1.3.0"
+      }
+    },
+    "node_modules/hypercore-id-encoding": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/hypercore-id-encoding/-/hypercore-id-encoding-1.3.0.tgz",
+      "integrity": "sha512-W6sHdGo5h7LXEsoWfKf/KfuROZmZRQDlGqJF2EPHW+noCK66Vvr0+zE6cL0vqQi18s0kQPeN7Sq3QyR0Ytc2VQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.5.3",
+        "z32": "^1.0.0"
       }
     },
     "node_modules/hypercore-protocol": {
@@ -2355,6 +2641,28 @@
         "uint64be": "^3.0.0"
       }
     },
+    "node_modules/hypercore-storage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-3.2.0.tgz",
+      "integrity": "sha512-i5O5ZMkdZaNAWGuNRXUZjuzv7B41OIhDHUwLCZPjucgVmywY0ZE5PDafu6e5oPuhtghjl6S8q6Jn+POVKN2BvQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.7",
+        "bare-path": "^3.0.0",
+        "compact-encoding": "^3.1.0",
+        "device-file": "^2.1.2",
+        "flat-tree": "^1.12.1",
+        "hypercore-crypto": "^3.4.2",
+        "hyperschema": "^1.21.0",
+        "index-encoder": "^3.3.2",
+        "resolve-reject-promise": "^1.0.0",
+        "rocksdb-native": "^3.11.0",
+        "scope-lock": "^1.2.4",
+        "streamx": "^2.21.1",
+        "xache": "^1.2.1"
+      }
+    },
     "node_modules/hypercore-streams": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hypercore-streams/-/hypercore-streams-1.0.1.tgz",
@@ -2364,21 +2672,50 @@
         "streamx": "^2.6.0"
       }
     },
-    "node_modules/hypercore/node_modules/sodium-universal": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.0.tgz",
-      "integrity": "sha512-iKHl8XnBV96k1c75gwwzANFdephw/MDWSjQAjPmBE+du0y3P23Q8uf7AcdcfFsYAMwLg7WVBfSAIBtV/JvRsjA==",
+    "node_modules/hypercore/node_modules/sodium-native": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.1.0.tgz",
+      "integrity": "sha512-3RxgyWyJlhTsABPnJVpCI5CoTDANZTqqFrEPqr+kjfnRaBihpVtMUE3yTF40ukdoB1APXeoBNKF3MzZAIHg39g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "blake2b": "^2.1.1",
-        "chacha20-universal": "^1.0.4",
-        "nanoassert": "^2.0.0",
-        "sha256-universal": "^1.1.0",
-        "sha512-universal": "^1.1.0",
-        "siphash24": "^1.0.1",
-        "sodium-javascript": "~0.8.0",
-        "sodium-native": "^4.0.0",
-        "xsalsa20": "^1.0.0"
+        "bare-assert": "^1.2.0",
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.1"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/hypercore/node_modules/sodium-universal": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-5.0.1.tgz",
+      "integrity": "sha512-rv+aH+tnKB5H0MAc2UadHShLMslpJsc4wjdnHRtiSIEYpOetCgu8MS4ExQRia+GL/MK3uuCyZPeEsi+J3h+Q+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sodium-native": "^5.0.1"
+      },
+      "peerDependencies": {
+        "sodium-javascript": "~0.8.0"
+      },
+      "peerDependenciesMeta": {
+        "sodium-javascript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/hyperschema": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/hyperschema/-/hyperschema-1.21.0.tgz",
+      "integrity": "sha512-lEnIbLTUQf7w6FU6X+R3yUJhBwCzF4ewRnAaYOrPdcVWe1rbOf94PzMiXb5pBKxroCXzlrPLxVujxAsTrrHc8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.0.1",
+        "compact-encoding": "^3.0.0",
+        "generate-object-property": "^2.0.0",
+        "generate-string": "^1.0.1"
       }
     },
     "node_modules/ignore": {
@@ -2431,6 +2768,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/index-encoder": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/index-encoder/-/index-encoder-3.5.0.tgz",
+      "integrity": "sha512-idZ1cxtZz2dRV6rUiaP9Xo99UjXbSzjcMacoQmxUMu/A7fEQcNPngvwDJYeWelQUS5XFlY71/or70lKn6XnwbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/inflight": {
@@ -2625,6 +2972,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -3550,6 +3904,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
       "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
+      "dev": true,
       "optional": true
     },
     "node_modules/natural-compare": {
@@ -3568,7 +3923,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
       "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -4119,15 +4474,17 @@
       "dev": true
     },
     "node_modules/protomux": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/protomux/-/protomux-3.4.0.tgz",
-      "integrity": "sha512-jZBytPrL5o+eZeSfIA+5OhPBwfS4A3DucHU4R6KkwFVr2sPqtNoKOX/xXdGzQzHzfVOqbsFfC7oFQ5FqZ6XKWw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/protomux/-/protomux-3.11.0.tgz",
+      "integrity": "sha512-Ze43XaNHbL6zQ/zJwVYvue7Aj8pDB1HNnISsrFhAur3291Y+Iu2fMhOpySD73J/32BoBIUYrhl07lJsBR/fUVA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "b4a": "^1.3.1",
-        "compact-encoding": "^2.5.1",
+        "compact-encoding": "^3.0.0",
         "queue-tick": "^1.0.0",
-        "safety-catch": "^1.0.1"
+        "safety-catch": "^1.0.1",
+        "unslab": "^1.3.0"
       }
     },
     "node_modules/pump": {
@@ -4175,29 +4532,28 @@
       "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
     },
     "node_modules/quickbit-native": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/quickbit-native/-/quickbit-native-2.1.5.tgz",
-      "integrity": "sha512-8fpUjEjqsDoHZezYEbWemf2DCayE6i83GFeCUm6OjSrkole5zDVIgv7lEoE1By+d7wJQnDi1IMNto3xZoWwKmQ==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/quickbit-native/-/quickbit-native-2.4.8.tgz",
+      "integrity": "sha512-FcCcqI+nIAWGknqhtrYT5TSD7t/N+Xd8ctM+2PrIIBuwOi5hx0SxAvuPtzLIEMfT/2h9+fhBakUe2uALOHX6yw==",
       "dev": true,
-      "hasInstallScript": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "b4a": "^1.6.0",
-        "napi-macros": "^2.0.0",
-        "node-gyp-build": "^4.2.3"
+        "require-addon": "^1.1.0"
       }
     },
     "node_modules/quickbit-universal": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/quickbit-universal/-/quickbit-universal-2.1.2.tgz",
-      "integrity": "sha512-fPEQ5G9rWm5p0eaBMgTT6+YZ6Ftw2hHgPbZu/olFv/GfeH3lr4LwSL28MFo6L7My572O5fQOIVtngboVtwKU1Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/quickbit-universal/-/quickbit-universal-2.2.0.tgz",
+      "integrity": "sha512-w02i1R8n7+6pEKTud8DfF8zbFY9o7RtPlUc3jWbtCkDKvhbx/AvV7oNnz4/TcmsPGpSJS+fq5Ud6RH6+YPvSGg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "b4a": "^1.6.0",
         "simdle-universal": "^1.1.0"
       },
       "optionalDependencies": {
-        "quickbit-native": "^2.1.3"
+        "quickbit-native": "^2.2.0"
       }
     },
     "node_modules/random-access-file": {
@@ -4298,6 +4654,36 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ready-resource": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ready-resource/-/ready-resource-1.2.0.tgz",
+      "integrity": "sha512-nfcco/8iAFV0M+2PYnmIc+/xY0iRb35d42HFHQ7AfjulbGEAFa+XWpByfwSyeVeiBoMLLFVMv1HixxNCqzSQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/refcounter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/refcounter/-/refcounter-1.0.0.tgz",
+      "integrity": "sha512-1WosVzUy0kPUaPMEtlNDwm99UsteALIhXXR8rerELoa63WkYIXAl0hxgwPFrIYBRWZPGUyekQ04FRtPJ7dHk9w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4323,6 +4709,20 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/resolve-reject-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-reject-promise/-/resolve-reject-promise-1.1.0.tgz",
+      "integrity": "sha512-LWsTOA91AqzBTjSGgX79Tc130pwcBK6xjpJEO+qRT5IKZ6bGnHKcc8QL3upUBcWuU8OTIDzKK2VNSwmmlqvAVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resource-on-exit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resource-on-exit/-/resource-on-exit-1.0.0.tgz",
+      "integrity": "sha512-ViJwJAknCkLRJRPR+9SISQQ7R5eRgtdIHLJsM2hHx1MweAJbJxJ5XnMjjq0Lc7ZGv44ufzAqds1nKxiVkdy4ag==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
@@ -4368,6 +4768,25 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rocksdb-native": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/rocksdb-native/-/rocksdb-native-3.17.2.tgz",
+      "integrity": "sha512-6kijLkb7NrUFCyWQsIxKIU/iQASxdqLDWrteAeXVEq1MJWrJUcXP6MDPRh8Ux7im2sBereDiI/D4vxYV2ia90A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0",
+        "ready-resource": "^1.0.0",
+        "refcounter": "^1.0.0",
+        "require-addon": "^1.0.2",
+        "resolve-reject-promise": "^1.1.0",
+        "signal-promise": "^1.0.3",
+        "streamx": "^2.16.1"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4401,10 +4820,18 @@
       }
     },
     "node_modules/safety-catch": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.1.tgz",
-      "integrity": "sha512-LmPpHuNn2nDbHf7t5xGcPRBsXUnCC1NTiEDQqZfC+okR+E6R3ihHjYiUv7qoa96VnJA52WkqRWJoEN8dSY6TCg==",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.3.tgz",
+      "integrity": "sha512-Zq+J1TefpoEq/HTUabo0YXX5MNvttjWYODGohgPBO2jfko8Wqx3JYMgE823szDFVamdH5PlpByvfiWScTdSYDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/scope-lock": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/scope-lock/-/scope-lock-1.2.4.tgz",
+      "integrity": "sha512-BpSd8VCuCxW9ZitcdIC/vjs3gMaP9bRBL5nkHcyfX2VrS52n13/rHuBA2xJ/S/4DPuRdAO/Bk8pWd8eD/gHCIA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/semver": {
       "version": "7.6.0",
@@ -4508,6 +4935,13 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/signal-promise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/signal-promise/-/signal-promise-1.0.3.tgz",
+      "integrity": "sha512-WBgv0UnIq2C+Aeh0/n+IRpP6967eIx9WpynTUoiW3isPpfe1zu2LJzyfXdo9Tgef8yR/sGjcMvoUXD7EYdiz+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/signed-varint": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
@@ -4518,16 +4952,15 @@
       }
     },
     "node_modules/simdle-native": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/simdle-native/-/simdle-native-1.1.3.tgz",
-      "integrity": "sha512-KuD5YD9kyZ7kOEhPWNyQnL+NIGSmYnykjvQ6Yc4RBpJVYcl7bx4z9Jx3bODwVqNhOgbwXbZUOoFXol9/VG74EA==",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/simdle-native/-/simdle-native-1.3.9.tgz",
+      "integrity": "sha512-Isc8sP4OiiIU0mpslD4GHEnR0VQWvR/54WN7YtwEDkNdTJVWtpmvsSvsgRlw5BNGxdYXlVRegdnrSu10H/PhvA==",
       "dev": true,
-      "hasInstallScript": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "b4a": "^1.6.0",
-        "napi-macros": "^2.0.0",
-        "node-gyp-build": "^4.2.3"
+        "require-addon": "^1.1.0"
       }
     },
     "node_modules/simdle-universal": {
@@ -4535,6 +4968,7 @@
       "resolved": "https://registry.npmjs.org/simdle-universal/-/simdle-universal-1.1.2.tgz",
       "integrity": "sha512-3n3w1bs+uwgHKQjt6arez83EywNlhZzYvNOhvAASTl/8KqNIcqr6aHyGt3JRlfuUC7iB0tomJRPlJ2cRGIpBzA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "b4a": "^1.6.0"
       },
@@ -4761,12 +5195,14 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
-      "integrity": "sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
       "dependencies": {
-        "fast-fifo": "^1.1.0",
-        "queue-tick": "^1.0.1"
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/string_decoder": {
@@ -4949,6 +5385,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -5012,6 +5458,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-table": {
@@ -5087,10 +5542,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5132,6 +5588,13 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
@@ -5171,6 +5634,16 @@
       "integrity": "sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg==",
       "dev": true
     },
+    "node_modules/unslab": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/unslab/-/unslab-1.3.0.tgz",
+      "integrity": "sha512-YATkfKAFj47kTzmiQrWXMyRvaVrHsW6MEALa4bm+FhiA2YG4oira+Z3DXN6LrYOYn2Y8eO94Lwl9DOHjs1FpoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.6"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5194,12 +5667,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/uv-errors": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/uv-errors/-/uv-errors-1.0.4.tgz",
-      "integrity": "sha512-6hlu1s0O+t+PHEMgAIVb+JxOOIyc4RdYaKwtDNJNQp6R3uMMBjfrSYysHTVgX/o1QQ0tBucwm/pIAkiXEBLxTA==",
-      "optional": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -5261,6 +5728,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-runtime": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.4.0.tgz",
+      "integrity": "sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==",
+      "devOptional": true,
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -5370,10 +5844,11 @@
       "dev": true
     },
     "node_modules/xache": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xache/-/xache-1.1.0.tgz",
-      "integrity": "sha512-RQGZDHLy/uCvnIrAvaorZH/e6Dfrtxj16iVlGjkj4KD2/G/dNXNqhk5IdSucv5nSSnDK00y8Y/2csyRdHveJ+Q==",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/xache/-/xache-1.3.0.tgz",
+      "integrity": "sha512-ekAknjLTiyXJcuezqwa/cOMfFenVVY2toL4J7D3AfTn7UEDYb8JSgRnv3CK8khF7u38XZ4NjS1MXEw4RwqJ4oA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xsalsa20": {
       "version": "1.2.0",
@@ -5787,9 +6262,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.16.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
-      "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA=="
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/sodium-native": {
       "version": "2.3.5",
@@ -5804,6 +6283,7 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@types/streamx/-/streamx-2.9.1.tgz",
       "integrity": "sha512-9bywzhouyedmci7WCIPFwJ8zASDnxt2gaVUy52X0p0Tt085IJSAEP0L6j4SSNeDMSLzpYu6cPz0GrJZ7kPJ6Bg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -5923,15 +6403,120 @@
       "dev": true
     },
     "b4a": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
-      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "requires": {}
     },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bare-addon-resolve": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz",
+      "integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
+      "devOptional": true,
+      "requires": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      }
+    },
+    "bare-ansi-escapes": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-ansi-escapes/-/bare-ansi-escapes-2.2.3.tgz",
+      "integrity": "sha512-02ES4/E2RbrtZSnHJ9LntBhYkLA6lPpSEeP8iqS3MccBIVhVBlEmruF1I7HZqx5Q8aiTeYfQVeqmrU9YO2yYoQ==",
+      "dev": true,
+      "requires": {
+        "bare-stream": "^2.6.5"
+      }
+    },
+    "bare-assert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bare-assert/-/bare-assert-1.2.0.tgz",
+      "integrity": "sha512-c6uvgvTJBspTDxtVnPgrBKmLgcpW3Fp72NVKDLg6oT4QjQbhGtvrkHMhGYMK1sh4vjBHOBmuUalyt9hSzV37fQ==",
+      "dev": true,
+      "requires": {
+        "bare-inspect": "^3.1.2"
+      }
+    },
+    "bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "requires": {}
+    },
+    "bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "dev": true,
+      "requires": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      }
+    },
+    "bare-inspect": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/bare-inspect/-/bare-inspect-3.1.4.tgz",
+      "integrity": "sha512-jfW5KRA84o3REpI6Vr4nbvMn+hqVAw8GU1mMdRwUsY5yJovQamxYeKGVKGqdzs+8ZbG4jRzGUXP/3Ji/DnqfPg==",
+      "dev": true,
+      "requires": {
+        "bare-ansi-escapes": "^2.1.0",
+        "bare-type": "^1.0.0"
+      }
+    },
+    "bare-module-resolve": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
+      "integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
+      "devOptional": true,
+      "requires": {
+        "bare-semver": "^1.0.0"
+      }
+    },
+    "bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "dev": true
+    },
+    "bare-semver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
+      "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
+      "devOptional": true
+    },
+    "bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "requires": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      }
+    },
+    "bare-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-type/-/bare-type-1.1.0.tgz",
+      "integrity": "sha512-LdtnnEEYldOc87Dr4GpsKnStStZk3zfgoEMXy8yvEZkXrcCv9RtYDrUYWFsBQHtaB0s1EUWmcvS6XmEZYIj3Bw==",
+      "dev": true
+    },
+    "bare-url": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+      "dev": true,
+      "requires": {
+        "bare-path": "^3.0.0"
+      }
     },
     "big-sparse-array": {
       "version": "1.0.3",
@@ -6388,9 +6973,9 @@
       "dev": true
     },
     "compact-encoding": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-2.11.0.tgz",
-      "integrity": "sha512-CRfTuyy9Tg7EwxNKvIq3yFIr2JnJLyVr9Yj234VsDCL59hdXcZH3TdzY/2kwbAqVogIoRBJjnNKCEnXbxTIEeg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.3.0.tgz",
+      "integrity": "sha512-e64XyzlBvTRJ3iScuU/U2w25Dglkm7fhrRbrGaHIwuTlNnzjRKMaQBCVl7mJRvZg7wI5a9wX1IVTXCuaAANNkw==",
       "dev": true,
       "requires": {
         "b4a": "^1.3.0"
@@ -6413,15 +6998,6 @@
       "resolved": "https://registry.npmjs.org/count-trailing-zeros/-/count-trailing-zeros-1.0.1.tgz",
       "integrity": "sha1-q6bFgzvkENRbHso+bVg4RM5oLHc=",
       "dev": true
-    },
-    "crc-universal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/crc-universal/-/crc-universal-1.0.2.tgz",
-      "integrity": "sha512-RrQ/8bT3WKNsGQuHWV3wf3Y0SUJTa8GADrkrQ1gsDljJLs8h/ENJRFUkL3z1TRWas80gv3Kdo6z1IPYyVJ/sxQ==",
-      "dev": true,
-      "requires": {
-        "node-gyp-build": "^4.5.0"
-      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -6473,6 +7049,20 @@
       "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
+      }
+    },
+    "device-file": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/device-file/-/device-file-2.3.1.tgz",
+      "integrity": "sha512-bmON44lwxJPle9N2OcH4tqM44pMGZKT8G6OkzXkz0urvqQ9LKkoQdTS6w0ztYfmLdUE27R4UUmx0+y2gEz4Jug==",
+      "dev": true,
+      "requires": {
+        "b4a": "^1.6.7",
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0",
+        "fd-lock": "^2.1.0",
+        "fs-native-extensions": "^1.4.0",
+        "ready-resource": "^1.2.0"
       }
     },
     "doctrine": {
@@ -6807,6 +7397,14 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
+    "events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "requires": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "execa": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -6840,9 +7438,9 @@
       "dev": true
     },
     "fast-fifo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
-      "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -6863,6 +7461,18 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "fd-lock": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fd-lock/-/fd-lock-2.2.0.tgz",
+      "integrity": "sha512-Il4jWBhjjgvUg+z8d0bC7ncXqB42caqKTUpnZ9jpcqiPmw8bkIixt7Kic1czbZPMxAQD/9kEqfZ5Dq77nSll0w==",
+      "dev": true,
+      "requires": {
+        "bare-fs": "^4.5.0",
+        "fs-native-extensions": "^1.4.4",
+        "ready-resource": "^1.2.0",
+        "resource-on-exit": "^1.0.0"
       }
     },
     "file-entry-cache": {
@@ -6904,9 +7514,9 @@
       }
     },
     "flat-tree": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/flat-tree/-/flat-tree-1.9.0.tgz",
-      "integrity": "sha512-WRu5/q9fcdL9f7L6Ahq8fR153e5Zr5aU6plPHupN6JDWuvEJbMjrEQprge3/I7ytndHC6/GUNg5Rg8XEisuv5w==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/flat-tree/-/flat-tree-1.13.0.tgz",
+      "integrity": "sha512-fT3HIuCPwHhFgJ20QYzDHgUG0zMmFg5cHvFiFo5h+QMSJ28TihsEVY0f8HGliuO+pOzmvjMx1odToeaEWkTnyQ==",
       "dev": true
     },
     "flatted": {
@@ -6934,14 +7544,13 @@
       }
     },
     "fs-native-extensions": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/fs-native-extensions/-/fs-native-extensions-1.2.2.tgz",
-      "integrity": "sha512-zpW4FsykyuKQqVIeXxi9J+6lPgg4PPyuegKS5nMSkb6oRwBsQga7wczKqi8vSjJ7K0TmNdQrCdF/7hOtjCqrpQ==",
-      "optional": true,
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/fs-native-extensions/-/fs-native-extensions-1.5.0.tgz",
+      "integrity": "sha512-nuZLFm9mGCxvyi7Llww/J4OyifKCS21nEUTAmnlTZp3FObPOvA32aCedCmt4Z+8yk+caqfClNaSCfn/P7T7FLQ==",
+      "devOptional": true,
       "requires": {
-        "napi-macros": "^2.0.0",
-        "node-gyp-build": "^4.2.3",
-        "uv-errors": "^1.0.1"
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.0"
       }
     },
     "fs.realpath": {
@@ -6965,6 +7574,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-2.0.0.tgz",
+      "integrity": "sha512-KwuURPyqn2Mz8DdV29pJwQu0Y7tcsbkULr82eeOcY/ZllFK6I9Wm8dsRByIu7CKWlFi9BdW1b3mcXMp/kQBQsw==",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "generate-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/generate-string/-/generate-string-1.0.1.tgz",
+      "integrity": "sha512-IfTY0dKZM43ACyGvXkbG7De7WY7MxTS5VO6Juhe8oJKpCmrYYXoqp/cJMskkpi0k9H8wuXq0H+eI898/BCqvXg==",
       "dev": true
     },
     "get-caller-file": {
@@ -7118,46 +7742,52 @@
       "dev": true
     },
     "hypercore": {
-      "version": "10.17.0",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-10.17.0.tgz",
-      "integrity": "sha512-Yp9lyfUjp81Gy1nPHemNFtYQtngliCGZ6prH+qxvjr2FPVG1QFtNqtOh+ZxFu4hXZ1dAOLYkQOA7Qq2vjFe64A==",
+      "version": "11.35.0",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-11.35.0.tgz",
+      "integrity": "sha512-ixba6oHaK2XXmv7nERLz7T6DUb9rsPc7OAMgG3wVbFELcX7x0RZkjUaupjgDEuK1VbiiNrH784+v95J9VdCC7w==",
       "dev": true,
       "requires": {
         "@hyperswarm/secret-stream": "^6.0.0",
         "b4a": "^1.1.0",
+        "bare-events": "^2.2.0",
         "big-sparse-array": "^1.0.3",
-        "compact-encoding": "^2.11.0",
-        "crc-universal": "^1.0.2",
-        "events": "^3.3.0",
+        "compact-encoding": "^3.0.0",
+        "fast-fifo": "^1.3.0",
         "flat-tree": "^1.9.0",
         "hypercore-crypto": "^3.2.1",
+        "hypercore-errors": "^1.5.0",
+        "hypercore-id-encoding": "^1.2.0",
+        "hypercore-storage": "^3.2.0",
         "is-options": "^1.0.1",
-        "protomux": "^3.4.0",
-        "quickbit-universal": "^2.1.1",
-        "random-access-file": "^4.0.0",
+        "nanoassert": "^2.0.0",
+        "protomux": "^3.5.0",
+        "quickbit-universal": "^2.2.0",
         "random-array-iterator": "^1.0.0",
         "safety-catch": "^1.0.1",
-        "sodium-universal": "^4.0.0",
+        "sodium-universal": "^5.0.1",
         "streamx": "^2.12.4",
-        "xache": "^1.1.0",
+        "unslab": "^1.3.0",
         "z32": "^1.0.0"
       },
       "dependencies": {
-        "sodium-universal": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.0.tgz",
-          "integrity": "sha512-iKHl8XnBV96k1c75gwwzANFdephw/MDWSjQAjPmBE+du0y3P23Q8uf7AcdcfFsYAMwLg7WVBfSAIBtV/JvRsjA==",
+        "sodium-native": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.1.0.tgz",
+          "integrity": "sha512-3RxgyWyJlhTsABPnJVpCI5CoTDANZTqqFrEPqr+kjfnRaBihpVtMUE3yTF40ukdoB1APXeoBNKF3MzZAIHg39g==",
           "dev": true,
           "requires": {
-            "blake2b": "^2.1.1",
-            "chacha20-universal": "^1.0.4",
-            "nanoassert": "^2.0.0",
-            "sha256-universal": "^1.1.0",
-            "sha512-universal": "^1.1.0",
-            "siphash24": "^1.0.1",
-            "sodium-javascript": "~0.8.0",
-            "sodium-native": "^4.0.0",
-            "xsalsa20": "^1.0.0"
+            "bare-assert": "^1.2.0",
+            "require-addon": "^1.1.0",
+            "which-runtime": "^1.2.1"
+          }
+        },
+        "sodium-universal": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-5.0.1.tgz",
+          "integrity": "sha512-rv+aH+tnKB5H0MAc2UadHShLMslpJsc4wjdnHRtiSIEYpOetCgu8MS4ExQRia+GL/MK3uuCyZPeEsi+J3h+Q+Q==",
+          "dev": true,
+          "requires": {
+            "sodium-native": "^5.0.1"
           }
         }
       }
@@ -7169,31 +7799,34 @@
       "dev": true
     },
     "hypercore-crypto": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-3.4.0.tgz",
-      "integrity": "sha512-0cZA1B58p1J84TDbTh8DMMIj7Qr7Rzz8NyGIo+ykUhdwD21gtjiiLWoME92QvN+lgbfu0Zfr9vwxT8sRmyg+AA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-3.7.0.tgz",
+      "integrity": "sha512-SWxobptQf2V/+ZLCCDRTXqFzGfTPIkNIuDyLKXpEMfcpJ1/ec94N9aWgylHcWOHmRt14ng/KR7z0BugebWHK9Q==",
       "dev": true,
       "requires": {
-        "b4a": "^1.1.0",
-        "compact-encoding": "^2.5.1",
-        "sodium-universal": "^4.0.0"
+        "b4a": "^1.6.6",
+        "compact-encoding": "^3.0.0",
+        "sodium-universal": "^5.0.0"
       },
       "dependencies": {
-        "sodium-universal": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.0.tgz",
-          "integrity": "sha512-iKHl8XnBV96k1c75gwwzANFdephw/MDWSjQAjPmBE+du0y3P23Q8uf7AcdcfFsYAMwLg7WVBfSAIBtV/JvRsjA==",
+        "sodium-native": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.1.0.tgz",
+          "integrity": "sha512-3RxgyWyJlhTsABPnJVpCI5CoTDANZTqqFrEPqr+kjfnRaBihpVtMUE3yTF40ukdoB1APXeoBNKF3MzZAIHg39g==",
           "dev": true,
           "requires": {
-            "blake2b": "^2.1.1",
-            "chacha20-universal": "^1.0.4",
-            "nanoassert": "^2.0.0",
-            "sha256-universal": "^1.1.0",
-            "sha512-universal": "^1.1.0",
-            "siphash24": "^1.0.1",
-            "sodium-javascript": "~0.8.0",
-            "sodium-native": "^4.0.0",
-            "xsalsa20": "^1.0.0"
+            "bare-assert": "^1.2.0",
+            "require-addon": "^1.1.0",
+            "which-runtime": "^1.2.1"
+          }
+        },
+        "sodium-universal": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-5.0.1.tgz",
+          "integrity": "sha512-rv+aH+tnKB5H0MAc2UadHShLMslpJsc4wjdnHRtiSIEYpOetCgu8MS4ExQRia+GL/MK3uuCyZPeEsi+J3h+Q+Q==",
+          "dev": true,
+          "requires": {
+            "sodium-native": "^5.0.1"
           }
         }
       }
@@ -7218,6 +7851,25 @@
             "random-access-storage": "^1.1.1"
           }
         }
+      }
+    },
+    "hypercore-errors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hypercore-errors/-/hypercore-errors-1.5.0.tgz",
+      "integrity": "sha512-5KQ/SuDxsvet+7qWA35Ay6zdD9WyAHQoyWHGcPUTbmJBd300gvNIJoi3oma7kp4TTCSzii6qYumNZe/s0j/saQ==",
+      "dev": true,
+      "requires": {
+        "hypercore-id-encoding": "^1.3.0"
+      }
+    },
+    "hypercore-id-encoding": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/hypercore-id-encoding/-/hypercore-id-encoding-1.3.0.tgz",
+      "integrity": "sha512-W6sHdGo5h7LXEsoWfKf/KfuROZmZRQDlGqJF2EPHW+noCK66Vvr0+zE6cL0vqQi18s0kQPeN7Sq3QyR0Ytc2VQ==",
+      "dev": true,
+      "requires": {
+        "b4a": "^1.5.3",
+        "z32": "^1.0.0"
       }
     },
     "hypercore-protocol": {
@@ -7249,6 +7901,27 @@
         }
       }
     },
+    "hypercore-storage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-3.2.0.tgz",
+      "integrity": "sha512-i5O5ZMkdZaNAWGuNRXUZjuzv7B41OIhDHUwLCZPjucgVmywY0ZE5PDafu6e5oPuhtghjl6S8q6Jn+POVKN2BvQ==",
+      "dev": true,
+      "requires": {
+        "b4a": "^1.6.7",
+        "bare-path": "^3.0.0",
+        "compact-encoding": "^3.1.0",
+        "device-file": "^2.1.2",
+        "flat-tree": "^1.12.1",
+        "hypercore-crypto": "^3.4.2",
+        "hyperschema": "^1.21.0",
+        "index-encoder": "^3.3.2",
+        "resolve-reject-promise": "^1.0.0",
+        "rocksdb-native": "^3.11.0",
+        "scope-lock": "^1.2.4",
+        "streamx": "^2.21.1",
+        "xache": "^1.2.1"
+      }
+    },
     "hypercore-streams": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hypercore-streams/-/hypercore-streams-1.0.1.tgz",
@@ -7256,6 +7929,18 @@
       "dev": true,
       "requires": {
         "streamx": "^2.6.0"
+      }
+    },
+    "hyperschema": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/hyperschema/-/hyperschema-1.21.0.tgz",
+      "integrity": "sha512-lEnIbLTUQf7w6FU6X+R3yUJhBwCzF4ewRnAaYOrPdcVWe1rbOf94PzMiXb5pBKxroCXzlrPLxVujxAsTrrHc8g==",
+      "dev": true,
+      "requires": {
+        "bare-fs": "^4.0.1",
+        "compact-encoding": "^3.0.0",
+        "generate-object-property": "^2.0.0",
+        "generate-string": "^1.0.1"
       }
     },
     "ignore": {
@@ -7293,6 +7978,15 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
+    },
+    "index-encoder": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/index-encoder/-/index-encoder-3.5.0.tgz",
+      "integrity": "sha512-idZ1cxtZz2dRV6rUiaP9Xo99UjXbSzjcMacoQmxUMu/A7fEQcNPngvwDJYeWelQUS5XFlY71/or70lKn6XnwbQ==",
+      "dev": true,
+      "requires": {
+        "b4a": "^1.6.4"
+      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -7431,6 +8125,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "dev": true
     },
     "is-regex": {
@@ -8131,6 +8831,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
       "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
+      "dev": true,
       "optional": true
     },
     "natural-compare": {
@@ -8149,7 +8850,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
       "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
-      "devOptional": true
+      "dev": true
     },
     "noise-curve-ed": {
       "version": "2.0.0",
@@ -8556,15 +9257,16 @@
       }
     },
     "protomux": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/protomux/-/protomux-3.4.0.tgz",
-      "integrity": "sha512-jZBytPrL5o+eZeSfIA+5OhPBwfS4A3DucHU4R6KkwFVr2sPqtNoKOX/xXdGzQzHzfVOqbsFfC7oFQ5FqZ6XKWw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/protomux/-/protomux-3.11.0.tgz",
+      "integrity": "sha512-Ze43XaNHbL6zQ/zJwVYvue7Aj8pDB1HNnISsrFhAur3291Y+Iu2fMhOpySD73J/32BoBIUYrhl07lJsBR/fUVA==",
       "dev": true,
       "requires": {
         "b4a": "^1.3.1",
-        "compact-encoding": "^2.5.1",
+        "compact-encoding": "^3.0.0",
         "queue-tick": "^1.0.0",
-        "safety-catch": "^1.0.1"
+        "safety-catch": "^1.0.1",
+        "unslab": "^1.3.0"
       }
     },
     "pump": {
@@ -8595,25 +9297,23 @@
       "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
     },
     "quickbit-native": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/quickbit-native/-/quickbit-native-2.1.5.tgz",
-      "integrity": "sha512-8fpUjEjqsDoHZezYEbWemf2DCayE6i83GFeCUm6OjSrkole5zDVIgv7lEoE1By+d7wJQnDi1IMNto3xZoWwKmQ==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/quickbit-native/-/quickbit-native-2.4.8.tgz",
+      "integrity": "sha512-FcCcqI+nIAWGknqhtrYT5TSD7t/N+Xd8ctM+2PrIIBuwOi5hx0SxAvuPtzLIEMfT/2h9+fhBakUe2uALOHX6yw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "b4a": "^1.6.0",
-        "napi-macros": "^2.0.0",
-        "node-gyp-build": "^4.2.3"
+        "require-addon": "^1.1.0"
       }
     },
     "quickbit-universal": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/quickbit-universal/-/quickbit-universal-2.1.2.tgz",
-      "integrity": "sha512-fPEQ5G9rWm5p0eaBMgTT6+YZ6Ftw2hHgPbZu/olFv/GfeH3lr4LwSL28MFo6L7My572O5fQOIVtngboVtwKU1Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/quickbit-universal/-/quickbit-universal-2.2.0.tgz",
+      "integrity": "sha512-w02i1R8n7+6pEKTud8DfF8zbFY9o7RtPlUc3jWbtCkDKvhbx/AvV7oNnz4/TcmsPGpSJS+fq5Ud6RH6+YPvSGg==",
       "dev": true,
       "requires": {
         "b4a": "^1.6.0",
-        "quickbit-native": "^2.1.3",
+        "quickbit-native": "^2.2.0",
         "simdle-universal": "^1.1.0"
       }
     },
@@ -8710,6 +9410,30 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "ready-resource": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ready-resource/-/ready-resource-1.2.0.tgz",
+      "integrity": "sha512-nfcco/8iAFV0M+2PYnmIc+/xY0iRb35d42HFHQ7AfjulbGEAFa+XWpByfwSyeVeiBoMLLFVMv1HixxNCqzSQ1g==",
+      "dev": true,
+      "requires": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "refcounter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/refcounter/-/refcounter-1.0.0.tgz",
+      "integrity": "sha512-1WosVzUy0kPUaPMEtlNDwm99UsteALIhXXR8rerELoa63WkYIXAl0hxgwPFrIYBRWZPGUyekQ04FRtPJ7dHk9w==",
+      "dev": true
+    },
+    "require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "devOptional": true,
+      "requires": {
+        "bare-addon-resolve": "^1.3.0"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8726,6 +9450,18 @@
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
+    },
+    "resolve-reject-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-reject-promise/-/resolve-reject-promise-1.1.0.tgz",
+      "integrity": "sha512-LWsTOA91AqzBTjSGgX79Tc130pwcBK6xjpJEO+qRT5IKZ6bGnHKcc8QL3upUBcWuU8OTIDzKK2VNSwmmlqvAVg==",
+      "dev": true
+    },
+    "resource-on-exit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resource-on-exit/-/resource-on-exit-1.0.0.tgz",
+      "integrity": "sha512-ViJwJAknCkLRJRPR+9SISQQ7R5eRgtdIHLJsM2hHx1MweAJbJxJ5XnMjjq0Lc7ZGv44ufzAqds1nKxiVkdy4ag==",
+      "dev": true
     },
     "restore-cursor": {
       "version": "3.1.0",
@@ -8758,6 +9494,21 @@
         "glob": "^7.1.3"
       }
     },
+    "rocksdb-native": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/rocksdb-native/-/rocksdb-native-3.17.2.tgz",
+      "integrity": "sha512-6kijLkb7NrUFCyWQsIxKIU/iQASxdqLDWrteAeXVEq1MJWrJUcXP6MDPRh8Ux7im2sBereDiI/D4vxYV2ia90A==",
+      "dev": true,
+      "requires": {
+        "compact-encoding": "^3.0.0",
+        "ready-resource": "^1.0.0",
+        "refcounter": "^1.0.0",
+        "require-addon": "^1.0.2",
+        "resolve-reject-promise": "^1.1.0",
+        "signal-promise": "^1.0.3",
+        "streamx": "^2.16.1"
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8777,9 +9528,15 @@
       }
     },
     "safety-catch": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.1.tgz",
-      "integrity": "sha512-LmPpHuNn2nDbHf7t5xGcPRBsXUnCC1NTiEDQqZfC+okR+E6R3ihHjYiUv7qoa96VnJA52WkqRWJoEN8dSY6TCg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.3.tgz",
+      "integrity": "sha512-Zq+J1TefpoEq/HTUabo0YXX5MNvttjWYODGohgPBO2jfko8Wqx3JYMgE823szDFVamdH5PlpByvfiWScTdSYDA==",
+      "dev": true
+    },
+    "scope-lock": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/scope-lock/-/scope-lock-1.2.4.tgz",
+      "integrity": "sha512-BpSd8VCuCxW9ZitcdIC/vjs3gMaP9bRBL5nkHcyfX2VrS52n13/rHuBA2xJ/S/4DPuRdAO/Bk8pWd8eD/gHCIA==",
       "dev": true
     },
     "semver": {
@@ -8869,6 +9626,12 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "signal-promise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/signal-promise/-/signal-promise-1.0.3.tgz",
+      "integrity": "sha512-WBgv0UnIq2C+Aeh0/n+IRpP6967eIx9WpynTUoiW3isPpfe1zu2LJzyfXdo9Tgef8yR/sGjcMvoUXD7EYdiz+g==",
+      "dev": true
+    },
     "signed-varint": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
@@ -8879,15 +9642,14 @@
       }
     },
     "simdle-native": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/simdle-native/-/simdle-native-1.1.3.tgz",
-      "integrity": "sha512-KuD5YD9kyZ7kOEhPWNyQnL+NIGSmYnykjvQ6Yc4RBpJVYcl7bx4z9Jx3bODwVqNhOgbwXbZUOoFXol9/VG74EA==",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/simdle-native/-/simdle-native-1.3.9.tgz",
+      "integrity": "sha512-Isc8sP4OiiIU0mpslD4GHEnR0VQWvR/54WN7YtwEDkNdTJVWtpmvsSvsgRlw5BNGxdYXlVRegdnrSu10H/PhvA==",
       "dev": true,
       "optional": true,
       "requires": {
         "b4a": "^1.6.0",
-        "napi-macros": "^2.0.0",
-        "node-gyp-build": "^4.2.3"
+        "require-addon": "^1.1.0"
       }
     },
     "simdle-universal": {
@@ -9101,12 +9863,13 @@
       }
     },
     "streamx": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
-      "integrity": "sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
       "requires": {
-        "fast-fifo": "^1.1.0",
-        "queue-tick": "^1.0.1"
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "string_decoder": {
@@ -9230,6 +9993,15 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "requires": {
+        "streamx": "^2.12.5"
+      }
+    },
     "temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -9271,6 +10043,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
+      }
+    },
+    "text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "requires": {
+        "b4a": "^1.6.4"
       }
     },
     "text-table": {
@@ -9337,9 +10117,9 @@
       }
     },
     "typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true
     },
     "uint64be": {
@@ -9369,6 +10149,12 @@
         "@fastify/busboy": "^2.0.0"
       }
     },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "unicorn-magic": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
@@ -9396,6 +10182,15 @@
       "integrity": "sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg==",
       "dev": true
     },
+    "unslab": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/unslab/-/unslab-1.3.0.tgz",
+      "integrity": "sha512-YATkfKAFj47kTzmiQrWXMyRvaVrHsW6MEALa4bm+FhiA2YG4oira+Z3DXN6LrYOYn2Y8eO94Lwl9DOHjs1FpoQ==",
+      "dev": true,
+      "requires": {
+        "b4a": "^1.6.6"
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -9416,12 +10211,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
-    },
-    "uv-errors": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/uv-errors/-/uv-errors-1.0.4.tgz",
-      "integrity": "sha512-6hlu1s0O+t+PHEMgAIVb+JxOOIyc4RdYaKwtDNJNQp6R3uMMBjfrSYysHTVgX/o1QQ0tBucwm/pIAkiXEBLxTA==",
-      "optional": true
     },
     "v8-to-istanbul": {
       "version": "9.2.0",
@@ -9471,6 +10260,12 @@
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
       }
+    },
+    "which-runtime": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.4.0.tgz",
+      "integrity": "sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==",
+      "devOptional": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -9553,9 +10348,9 @@
       "dev": true
     },
     "xache": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xache/-/xache-1.1.0.tgz",
-      "integrity": "sha512-RQGZDHLy/uCvnIrAvaorZH/e6Dfrtxj16iVlGjkj4KD2/G/dNXNqhk5IdSucv5nSSnDK00y8Y/2csyRdHveJ+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/xache/-/xache-1.3.0.tgz",
+      "integrity": "sha512-ekAknjLTiyXJcuezqwa/cOMfFenVVY2toL4J7D3AfTn7UEDYb8JSgRnv3CK8khF7u38XZ4NjS1MXEw4RwqJ4oA==",
       "dev": true
     },
     "xsalsa20": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -780,7 +780,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
       "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/bare-semver": {
@@ -832,7 +832,7 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
       "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -6484,7 +6484,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
       "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
-      "dev": true
+      "devOptional": true
     },
     "bare-semver": {
       "version": "1.1.0",
@@ -6513,7 +6513,7 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
       "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "bare-path": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "run-p lint type borp",
     "lint": "eslint .",
-    "borp": "c8 borp",
+    "borp": "c8 borp --concurrency 1",
     "type": "tsc",
     "prepare": "husky install",
     "prepack": "tsc",
@@ -16,24 +16,26 @@
   "keywords": [],
   "author": "Digital Democracy",
   "license": "MIT",
+  "peerDependencies": {
+    "hypercore": "^11.0.0"
+  },
   "dependencies": {
-    "@types/node": "^18.16.19",
-    "@types/streamx": "^2.9.1",
     "b4a": "^1.6.4",
     "big-sparse-array": "^1.0.2",
     "random-access-file": "^4.0.4",
-    "streamx": "^2.15.0",
+    "streamx": "^2.28.0",
     "tiny-typed-emitter": "^2.1.0"
   },
   "devDependencies": {
     "@digidem/types": "^1.0.1",
     "@types/nanobench": "^3.0.0",
+    "@types/node": "^18.19.130",
     "@types/sodium-native": "^2.3.5",
     "borp": "^0.9.1",
     "c8": "^9.1.0",
     "eslint": "^8.44.0",
     "husky": "^8.0.3",
-    "hypercore": "^10.17.0",
+    "hypercore": "^11.35.0",
     "lint-staged": "^13.2.3",
     "multifeed": "^6.0.0",
     "multifeed-index": "^3.4.2",
@@ -44,7 +46,7 @@
     "random-access-memory": "^6.2.0",
     "sodium-native": "^4.0.4",
     "tempy": "^3.0.0",
-    "typescript": "^5.1.6"
+    "typescript": "~5.8.3"
   },
   "eslintConfig": {
     "env": {

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,7 +1,9 @@
 // @ts-check
 
 const Hypercore = require('hypercore')
-const ram = require('random-access-memory')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 
 const BLOCK_LENGTH = Buffer.from('block000000').byteLength
 
@@ -10,6 +12,9 @@ const BLOCK_LENGTH = Buffer.from('block000000').byteLength
 
 module.exports = {
   create,
+  createTempDir,
+  trackCore,
+  closeCreatedCores,
   replicate,
   generateFixture,
   generateFixtures,
@@ -17,8 +22,36 @@ module.exports = {
   throttledDrain,
   throttledIdle,
   sortEntries,
+  uniqueEntries,
   logEntries,
   blocksToExpected,
+}
+
+/** @type {string[]} */
+const tempDirs = []
+
+// Hypercore 11 requires real disk storage (RocksDB), so tests create
+// temporary directories which are cleaned up when the test process exits.
+process.on('exit', () => {
+  for (const dir of tempDirs) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true })
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+})
+
+/**
+ * Create a temporary directory for core or index storage, removed on process
+ * exit.
+ *
+ * @returns {string}
+ */
+function createTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'multi-core-indexer-'))
+  tempDirs.push(dir)
+  return dir
 }
 
 /**
@@ -40,9 +73,36 @@ function replicate(a, b) {
   return [s1, s2]
 }
 
+/** @type {Hypercore[]} */
+const createdCores = []
+
+/**
+ * Track a core so that it is closed by closeCreatedCores()
+ *
+ * @template {Hypercore} T
+ * @param {T} core
+ * @returns {T}
+ */
+function trackCore(core) {
+  createdCores.push(core)
+  return core
+}
+
+/**
+ * Close all cores created via create() or trackCore(). Call this from a
+ * test.afterEach() hook: cores are backed by RocksDB storage, so leaving them
+ * open between tests leaks native resources and slows later tests.
+ */
+async function closeCreatedCores() {
+  const closing = createdCores.splice(0, createdCores.length)
+  await Promise.all(closing.map((core) => core.close().catch(noop)))
+}
+
+function noop() {}
+
 /** @param {any} args */
 async function create(...args) {
-  const core = new Hypercore(ram, ...args)
+  const core = trackCore(new Hypercore(createTempDir(), ...args))
   await core.ready()
   return core
 }
@@ -83,10 +143,15 @@ async function generateFixtures(cores, count) {
   return entries
 }
 
+// How long a stream must remain drained/idle before we consider it done.
+// Needs to comfortably cover the latency of disk (RocksDB) reads and writes,
+// which can leave the stream drained for longer than this between events.
+const QUIET_WINDOW_MS = 100
+
 /**
  * The index stream can become momentarily drained between reads and
  * appends/downloads of new data. This throttle drained will resolve only when
- * the stream has remained drained for > 10ms
+ * the stream has remained drained for > QUIET_WINDOW_MS
  * @param {EventEmitter} emitter
  * @returns {Promise<void>}
  */
@@ -114,7 +179,7 @@ function throttledStreamEvent(emitter, eventName) {
         emitter.off(eventName, onEvent)
         emitter.off('indexing', onIndexing)
         resolve()
-      }, 10)
+      }, QUIET_WINDOW_MS)
     }
 
     emitter.on(eventName, onEvent)
@@ -140,6 +205,23 @@ function sort(a, b) {
 /** @param {Entry[]} e */
 function sortEntries(e) {
   return e.sort(sort)
+}
+
+/**
+ * Dedupe entries by core key + index. Delivery is at-least-once, so
+ * assertions on entries delivered across an unclean close should compare
+ * unique entries, allowing duplicates.
+ *
+ * @param {Entry[]} entries
+ * @returns {Entry[]}
+ */
+function uniqueEntries(entries) {
+  /** @type {Map<string, Entry>} */
+  const byId = new Map()
+  for (const entry of entries) {
+    byId.set(entry.key.toString('hex') + ':' + entry.index, entry)
+  }
+  return [...byId.values()]
 }
 
 /**

--- a/test/multi-core-indexer.test.js
+++ b/test/multi-core-indexer.test.js
@@ -2,35 +2,49 @@
 const MultiCoreIndexer = require('../')
 const test = require('node:test')
 const assert = require('node:assert/strict')
+const { once } = require('node:events')
+const { spawnSync } = require('node:child_process')
+const path = require('node:path')
 const { setTimeout: delay } = require('node:timers/promises')
 const ram = require('random-access-memory')
 const {
   create,
+  createTempDir,
+  trackCore,
+  closeCreatedCores,
   replicate,
   generateFixtures,
   createMultiple,
   sortEntries,
+  uniqueEntries,
 } = require('./helpers')
 const { testKeypairs, expectedStorageNames } = require('./fixtures.js')
 const { pDefer } = require('../lib/utils.js')
 const Hypercore = require('hypercore')
+const RandomAccessFile = require('random-access-file')
 
 /** @typedef {import('../lib/types').Entry<'binary'>} Entry */
+
+// Cores are backed by RocksDB storage: close them after each test so native
+// resources don't accumulate across tests
+test.afterEach(() => closeCreatedCores())
 
 test('Indexer waits for core to be ready before idling', async (t) => {
   const delayingCoreReady = pDefer()
   t.after(() => delayingCoreReady.resolve({}))
 
-  const core = new Hypercore(ram, {
-    preload: () => delayingCoreReady.promise,
-  })
+  const core = trackCore(
+    new Hypercore(createTempDir(), {
+      preload: () => delayingCoreReady.promise,
+    })
+  )
   assert(!isCoreReady(core), 'test setup: core is not ready at the start')
 
   const indexer = new MultiCoreIndexer([core], {
     batch: async () => {
       assert.fail('This should never be called')
     },
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   t.after(() => indexer.close())
 
@@ -53,10 +67,12 @@ test('Indexes all items already in a core', async () => {
   const expected = await generateFixtures(cores, 100)
   /** @type {Entry[]} */
   const entries = []
-  /** @type {ram[]} */
+  const storageDir = createTempDir()
+  /** @type {import('random-access-file')[]} */
   const storages = []
-  function createStorage() {
-    const storage = new ram()
+  /** @param {string} name */
+  function createStorage(name) {
+    const storage = new RandomAccessFile(name, { directory: storageDir })
     storages.push(storage)
     return storage
   }
@@ -87,7 +103,7 @@ test('Indexes all items already in a core (some empty cores)', async () => {
       entries.push(...data)
     },
     maxBatch: 50,
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   await indexer.idle()
   assert.deepEqual(sortEntries(entries), sortEntries(expected))
@@ -104,7 +120,7 @@ test('Multiple .idle() awaits', async () => {
       entries.push(...data)
     },
     maxBatch: 50,
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   await Promise.all([indexer.idle(), indexer.idle(), indexer.idle()])
   assert.deepEqual(sortEntries(entries), sortEntries(expected))
@@ -120,7 +136,7 @@ test('Indexes items appended after initial index', async () => {
       entries.push(...data)
     },
     maxBatch: 50,
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   const expected = await generateFixtures(cores, 100)
   await indexer.idle()
@@ -131,7 +147,7 @@ test('Indexes items appended after initial index', async () => {
 test('State transitions', async () => {
   const indexer = new MultiCoreIndexer([], {
     batch: async () => {},
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   assert.equal(indexer.state.current, 'idle', 'starts in idle state')
   await indexer.idle()
@@ -163,7 +179,7 @@ test('Calling idle() when already idle still resolves', async () => {
     batch: async (data) => {
       entries.push(...data)
     },
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   await indexer.idle()
   assert.deepEqual(sortEntries(entries), sortEntries(expected))
@@ -180,7 +196,7 @@ test('Indexes cores added with addCore method', async () => {
       entries.push(...data)
     },
     maxBatch: 50,
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   const initialExpected = await generateFixtures(cores, 100)
   await indexer.idle()
@@ -223,7 +239,7 @@ test('index sparse hypercores', async () => {
     batch: async (data) => {
       entries.push(...data)
     },
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   await indexer.idle()
 
@@ -259,7 +275,7 @@ test('Appends from a replicated core are indexed', async () => {
     batch: async (data) => {
       entries.push(...data)
     },
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   await indexer.idle()
   assert.deepEqual(sortEntries(entries), sortEntries(expected1))
@@ -351,7 +367,7 @@ test('Entries are re-indexed if index storage reset', async () => {
     batch: async (data) => {
       entries1.push(...data)
     },
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   await indexer1.idle()
   assert.deepEqual(sortEntries(entries1), sortEntries(expected))
@@ -363,7 +379,7 @@ test('Entries are re-indexed if index storage reset', async () => {
     batch: async (data) => {
       entries2.push(...data)
     },
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   await indexer2.idle()
   assert.deepEqual(sortEntries(entries2), sortEntries(expected))
@@ -373,11 +389,11 @@ test('Entries are re-indexed if index storage reset', async () => {
 test('Entries are re-indexed if index storage unlinked', async () => {
   const cores = await createMultiple(5)
 
-  const createRAM = ram.reusable()
+  const storageDir = createTempDir()
 
   const indexer1 = new MultiCoreIndexer(cores, {
     batch: async () => {},
-    storage: createRAM,
+    storage: storageDir,
   })
   const expected = await generateFixtures(cores, 3)
   await indexer1.idle()
@@ -390,7 +406,7 @@ test('Entries are re-indexed if index storage unlinked', async () => {
     batch: async (data) => {
       entries.push(...data)
     },
-    storage: createRAM,
+    storage: storageDir,
   })
   await indexer2.idle()
 
@@ -406,7 +422,7 @@ test('Entries can be explicitly reindexed with a startup option', async (t) => {
   const expectedIn3 = new Set(await generateFixtures([core3], 3))
   const allExpected = new Set([...expectedIn1And2, ...expectedIn3])
 
-  const storage = ram.reusable()
+  const storage = createTempDir()
 
   /** @type {Set<Entry>} */ const entriesBeforeReindex = new Set()
   const indexer1 = new MultiCoreIndexer(cores, {
@@ -451,12 +467,17 @@ test('Entries are batched to batchMax when indexing is slower than Hypercore rea
     const indexer = new MultiCoreIndexer(cores, {
       batch: async (data) => {
         batchSizes.push(data.length)
-        await new Promise((res) => setTimeout(res, 50))
+        // Scale the batch duration with batch size so that reads from disk
+        // storage can always fill the stream buffer while a batch is
+        // processed, keeping indexing slower than reads
+        await new Promise((res) => setTimeout(res, batchSize))
       },
       maxBatch: batchSize,
-      storage: () => new ram(),
+      storage: createTempDir(),
     })
     await indexer.idle()
+    // The first batch (before the stream buffer fills) and the final batch
+    // are expected to be smaller than maxBatch
     assert.ok(
       batchSizes.filter((size) => size < batchSize).length <= 2,
       `Most batches are ${batchSize}`
@@ -476,7 +497,7 @@ test('Batches smaller than maxBatch when indexing is faster than hypercore reads
       batchSizes.push(data.length)
     },
     maxBatch: batchSize,
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   await indexer.idle()
   assert.ok(
@@ -487,7 +508,10 @@ test('Batches smaller than maxBatch when indexing is faster than hypercore reads
 })
 
 test('sync state / progress', async () => {
-  const expectedVariation = 0.2
+  // The rate is a moving average, and with cores on real disk storage a
+  // single slow disk read/write can briefly push it 20-25% off the true
+  // rate, so allow a wider variation than the typical <5%
+  const expectedVariation = 0.35
   const numberOfCores = 5
   const entriesPerCore = 1000
   const cores = await createMultiple(numberOfCores)
@@ -500,7 +524,7 @@ test('sync state / progress', async () => {
       // Simulate a batch function whose duration changes linearly with batch size
       await new Promise((res) => setTimeout(res, data.length))
     },
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   indexer.on('index-state', (state) => stateEvents.push(state))
   await indexer.idle()
@@ -515,17 +539,27 @@ test('sync state / progress', async () => {
   // Ends with idle and 0 remaining
   assert.equal(stateEvents[stateEvents.length - 1].current, 'idle')
   assert.equal(stateEvents[stateEvents.length - 1].remaining, 0)
+  // Ignore first two events, as they are not representative of the actual rate
+  const deviations = stateEvents.slice(2).map((state) => {
+    return Math.abs(state.entriesPerSecond - actualRate) / actualRate
+  })
   assert.ok(
-    // Ignore first two events, as they are not representative of the actual rate
-    stateEvents.slice(2).every((state) => {
-      return (
-        Math.abs(state.entriesPerSecond - actualRate) / actualRate <=
-        expectedVariation
-      )
-    }),
+    deviations.every((deviation) => deviation <= expectedVariation),
     `state.entriesPerSecond is within ${
       expectedVariation * 100
     }% of actual rate`
+  )
+  // The wide bound above is for one-off disk stalls; the typical deviation
+  // must be much smaller, so that a systematic error in the rate estimate
+  // cannot hide inside the wide bound
+  const medianDeviation = deviations.sort((a, b) => a - b)[
+    Math.floor(deviations.length / 2)
+  ]
+  assert.ok(
+    medianDeviation <= 0.15,
+    `median deviation of state.entriesPerSecond is within 15% of actual rate (got ${Math.round(
+      medianDeviation * 100
+    )}%)`
   )
 
   await indexer.close()
@@ -538,7 +572,7 @@ test('state getter', async () => {
     batch: async (data) => {
       entries.push(...data)
     },
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   assert.deepEqual(indexer.state.current, 'indexing')
   await indexer.idle()
@@ -554,7 +588,7 @@ test('empty cores, no indexing event before idle', async () => {
   const cores = await createMultiple(2)
   const indexer = new MultiCoreIndexer(cores, {
     batch: async () => {},
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   indexer.on('index-state', (state) => {
     if (state.current === 'indexing') assert.fail()
@@ -578,7 +612,7 @@ test('state.remaining does not update until after batch function resolves', asyn
       )
       entries.push(...data)
     },
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   await indexer.idle()
   assert.deepEqual(indexer.state.current, 'idle')
@@ -589,7 +623,7 @@ test('state.remaining does not update until after batch function resolves', asyn
 test('Closing before batch complete should resume on next start', async () => {
   const cores = await createMultiple(5)
   const expected = await generateFixtures(cores, 1000)
-  const createRAM = ram.reusable()
+  const storageDir = createTempDir()
 
   /** @type {Entry[]} */
   const entries = []
@@ -597,7 +631,7 @@ test('Closing before batch complete should resume on next start', async () => {
     batch: async (data) => {
       entries.push(...data)
     },
-    storage: createRAM,
+    storage: storageDir,
   })
   // Wait until indexing is half-done, then close the indexer.
   await /** @type {Promise<void>} */ (
@@ -620,22 +654,26 @@ test('Closing before batch complete should resume on next start', async () => {
     batch: async (data) => {
       entries.push(...data)
     },
-    storage: createRAM,
+    storage: storageDir,
   })
   await indexer2.idle()
-  assert.equal(entries.length, expected.length)
-  // t.same(sortEntries(entries), sortEntries(expected))
+  assert.deepEqual(
+    sortEntries(uniqueEntries(entries)),
+    sortEntries(expected),
+    'every entry is indexed at least once (delivery is at-least-once, so a batch in flight at close may be re-delivered)'
+  )
   await indexer2.close()
 })
 
 test('double-closing is a no-op', async (t) => {
   const indexer = new MultiCoreIndexer([], {
     batch: async () => {},
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   const closePromise = indexer.close()
   t.after(() => closePromise)
 
+  assert.equal(indexer.close(), closePromise, 'returns the same promise')
   await assert.doesNotReject(() => indexer.close())
 })
 
@@ -643,7 +681,7 @@ test('closing causes many methods to fail', async (t) => {
   {
     const indexer = new MultiCoreIndexer([], {
       batch: async () => {},
-      storage: () => new ram(),
+      storage: createTempDir(),
     })
     const closePromise = indexer.close()
     t.after(() => closePromise)
@@ -654,7 +692,7 @@ test('closing causes many methods to fail', async (t) => {
   {
     const indexer = new MultiCoreIndexer([], {
       batch: async () => {},
-      storage: () => new ram(),
+      storage: createTempDir(),
     })
     const closePromise = indexer.close()
     t.after(() => closePromise)
@@ -665,7 +703,7 @@ test('closing causes many methods to fail', async (t) => {
 test('closing resolves existing idle promises', async () => {
   const indexer = new MultiCoreIndexer([], {
     batch: async () => {},
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
 
   const core = await create()
@@ -681,7 +719,7 @@ test('closing resolves existing idle promises', async () => {
 test('unlinking requires the indexer to be closed', async () => {
   const indexer = new MultiCoreIndexer([], {
     batch: async () => {},
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
 
   await indexer.idle()
@@ -703,7 +741,9 @@ test('Consistent storage folders', async () => {
   const storageNames = []
   const cores = []
   for (const keyPair of testKeypairs.slice(0, 5)) {
-    cores.push(await create({ keyPair }))
+    // compat: true creates cores whose key is the raw public key, as in
+    // hypercore 10, so that these fixture storage names stay stable
+    cores.push(await create({ keyPair, compat: true }))
   }
   function createStorage(name) {
     storageNames.push(name)
@@ -714,7 +754,7 @@ test('Consistent storage folders', async () => {
     storage: createStorage,
   })
   for (const keyPair of testKeypairs.slice(5)) {
-    indexer.addCore(await create({ keyPair }))
+    indexer.addCore(await create({ keyPair, compat: true }))
   }
   await indexer.idle()
   assert.deepEqual(storageNames.sort(), expectedStorageNames)
@@ -724,11 +764,11 @@ test('Works with non-ready cores', async () => {
   /** @type {Hypercore[]} */
   const cores = []
   for (let i = 0; i < 5; i++) {
-    cores.push(new Hypercore(() => new ram()))
+    cores.push(trackCore(new Hypercore(createTempDir())))
   }
   const indexer = new MultiCoreIndexer(cores, {
     batch: async () => {},
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   assert.equal(indexer.state.current, 'indexing')
   await indexer.idle()
@@ -738,17 +778,17 @@ test('Works with non-ready cores', async () => {
 test('Indexes all items already in a core - cores not ready', async () => {
   /** @type {Hypercore[]} */
   const cores = []
-  /** @type {Array<ReturnType<(typeof ram)['reusable']>>} */
-  const storages = []
+  /** @type {string[]} */
+  const coreDirs = []
   for (let i = 0; i < 5; i++) {
-    const storage = ram.reusable()
-    storages.push(storage)
-    cores.push(new Hypercore(storage))
+    const dir = createTempDir()
+    coreDirs.push(dir)
+    cores.push(trackCore(new Hypercore(dir)))
   }
   const expected = await generateFixtures(cores, 100)
   await Promise.all(cores.map((core) => core.close()))
   for (let i = 0; i < 5; i++) {
-    cores[i] = new Hypercore(storages[i])
+    cores[i] = trackCore(new Hypercore(coreDirs[i]))
   }
   /** @type {Entry[]} */
   const entries = []
@@ -756,7 +796,7 @@ test('Indexes all items already in a core - cores not ready', async () => {
     batch: async (data) => {
       entries.push(...data)
     },
-    storage: () => new ram(),
+    storage: createTempDir(),
   })
   await indexer.idle()
   assert.deepEqual(sortEntries(entries), sortEntries(expected))
@@ -770,3 +810,301 @@ test('Indexes all items already in a core - cores not ready', async () => {
 function isCoreReady(core) {
   return core.writable
 }
+
+test('Batch callback rejection emits error and indexer still closes', async () => {
+  const cores = await createMultiple(2)
+  await generateFixtures(cores, 100)
+  const batchError = new Error('batch failed')
+  const indexer = new MultiCoreIndexer(cores, {
+    batch: async () => {
+      throw batchError
+    },
+    storage: createTempDir(),
+  })
+  /** @type {Error[]} */
+  const errors = []
+  indexer.on('error', (error) => errors.push(error))
+  const idlePromise = indexer.idle()
+  const [err] = await once(indexer, 'error')
+  assert.equal(err, batchError, "batch error is emitted as an 'error' event")
+  await assert.rejects(
+    () => idlePromise,
+    /batch failed/,
+    'pending idle() rejects with the batch error'
+  )
+  await assert.rejects(
+    () => indexer.idle(),
+    /Cannot await idle/,
+    'idle() called after the error rejects'
+  )
+  assert.throws(
+    () => indexer.addCore(cores[0]),
+    /Cannot add core/,
+    'addCore() called after the error throws'
+  )
+  const closePromise = indexer.close()
+  assert.equal(
+    indexer.close(),
+    closePromise,
+    'close() after the error returns the same promise'
+  )
+  await assert.doesNotReject(() => closePromise, 'close() still resolves')
+  assert.equal(indexer.state.current, 'closed')
+  assert.equal(errors.length, 1, "'error' is emitted only once")
+})
+
+test('Closing a core while indexing: indexer idles, resumes after reopen', async () => {
+  const coreDir = createTempDir()
+  const storageDir = createTempDir()
+  const core = trackCore(new Hypercore(coreDir))
+  await core.ready()
+  const expected = await generateFixtures([core], 1000)
+
+  /** @type {Entry[]} */
+  const entries1 = []
+  const indexer1 = new MultiCoreIndexer([core], {
+    batch: async (data) => {
+      entries1.push(...data)
+      // Slow batches so the core is closed while indexing is in progress
+      await delay(10)
+    },
+    storage: storageDir,
+  })
+  await once(indexer1, 'index-state')
+  await core.close()
+  // The closed core has nothing more that can be indexed, so the indexer
+  // must reach idle (rather than hang) even though not everything is indexed
+  await indexer1.idle()
+  assert.ok(
+    entries1.length < expected.length,
+    'test setup: core closed before indexing completed'
+  )
+  await indexer1.close()
+
+  // A new indexer for the re-opened core picks up where indexing stopped
+  const reopened = trackCore(new Hypercore(coreDir))
+  /** @type {Entry[]} */
+  const entries2 = []
+  const indexer2 = new MultiCoreIndexer([reopened], {
+    batch: async (data) => {
+      entries2.push(...data)
+    },
+    storage: storageDir,
+  })
+  await indexer2.idle()
+  await indexer2.close()
+  assert.deepEqual(
+    sortEntries(uniqueEntries([...entries1, ...entries2])),
+    sortEntries(expected),
+    'every entry is indexed at least once across both indexers'
+  )
+})
+
+test('Closing a core after indexing completes: idle() still resolves', async () => {
+  const core = trackCore(new Hypercore(createTempDir()))
+  await core.ready()
+  await generateFixtures([core], 10)
+  const indexer = new MultiCoreIndexer([core], {
+    batch: async () => {},
+    storage: createTempDir(),
+  })
+  await indexer.idle()
+  // core.close() drops core.length to 0 synchronously, before the indexer
+  // observes the close: `remaining` must not go negative or flip the state
+  // back to 'indexing' in that window
+  const coreClosePromise = core.close()
+  assert.equal(indexer.state.remaining, 0, 'remaining stays 0 during close')
+  assert.equal(indexer.state.current, 'idle', 'state stays idle during close')
+  await indexer.idle()
+  await coreClosePromise
+  await indexer.idle()
+  assert.equal(indexer.state.remaining, 0)
+  await indexer.close()
+})
+
+test('Index storage write failure (disk full) is emitted as an error', async () => {
+  const cores = await createMultiple(1)
+  await generateFixtures(cores, 10)
+  // Shaped like the error an fs write callback delivers on a full disk,
+  // which is how index-storage failures typically show up on mobile
+  const storageError = Object.assign(
+    new Error('ENOSPC: no space left on device, write'),
+    { code: 'ENOSPC' }
+  )
+  let failWrites = false
+  const indexer = new MultiCoreIndexer(cores, {
+    batch: async () => {},
+    storage: () => {
+      const storage = new ram()
+      const originalWrite = storage._write.bind(storage)
+      // @ts-ignore - patching the internal write method to fail on demand
+      storage._write = (req) => {
+        if (failWrites) {
+          process.nextTick(() => req.callback(storageError))
+        } else {
+          originalWrite(req)
+        }
+      }
+      return storage
+    },
+  })
+  await indexer.idle()
+  failWrites = true
+  /** @type {Error[]} */
+  const errors = []
+  indexer.on('error', (error) => errors.push(error))
+  const errorPromise = once(indexer, 'error')
+  await generateFixtures(cores, 10)
+  // The failing writes surface on the next flush of index state. Whether the
+  // flush after this batch has anything to write depends on timing, so
+  // trigger another read cycle if the indexer managed to reach idle
+  const raced = await Promise.race([
+    errorPromise.then(() => 'error'),
+    indexer.idle().then(
+      () => 'idle',
+      () => 'error'
+    ),
+  ])
+  if (raced === 'idle') await generateFixtures(cores, 10)
+  const [err] = await errorPromise
+  assert.equal(err, storageError, 'storage error is emitted')
+  assert.equal(
+    err.code,
+    'ENOSPC',
+    'the error code is preserved, so consumers can classify disk-full errors'
+  )
+  await assert.doesNotReject(() => indexer.close(), 'close() still resolves')
+  assert.equal(indexer.state.current, 'closed')
+  assert.equal(errors.length, 1, "'error' is emitted only once")
+})
+
+test('Core read failure is emitted as an indexer error', async () => {
+  const cores = await createMultiple(1)
+  await generateFixtures(cores, 10)
+  const readError = Object.assign(new Error('EIO: i/o error, read'), {
+    code: 'EIO',
+  })
+  const core = cores[0]
+  const originalGet = core.get.bind(core)
+  // Simulate a storage-level read failure for a single block (see the
+  // equivalent core-index-stream unit test for why get() is patched)
+  // @ts-ignore - patching for the test
+  core.get = (index, opts) =>
+    index === 5 ? Promise.reject(readError) : originalGet(index, opts)
+  const indexer = new MultiCoreIndexer(cores, {
+    batch: async () => {},
+    storage: createTempDir(),
+  })
+  const [err] = await once(indexer, 'error')
+  assert.equal(err, readError, 'the read error reaches the indexer consumer')
+  await assert.doesNotReject(() => indexer.close(), 'close() still resolves')
+  assert.equal(indexer.state.current, 'closed')
+})
+
+test('Entries in an unfinished batch when closing are re-delivered on restart', async () => {
+  const coreDir = createTempDir()
+  const storageDir = createTempDir()
+  const core = trackCore(new Hypercore(coreDir))
+  await core.ready()
+  const expected = await generateFixtures([core], 100)
+
+  /** @type {Entry[]} */
+  const entries1 = []
+  const batchStarted = pDefer()
+  const batchGate = pDefer()
+  let firstBatch = true
+  const indexer1 = new MultiCoreIndexer([core], {
+    batch: async (data) => {
+      entries1.push(...data)
+      if (firstBatch) {
+        firstBatch = false
+        batchStarted.resolve()
+        // Hold the first batch in flight until close() has been called
+        await batchGate.promise
+      }
+    },
+    storage: storageDir,
+  })
+  await batchStarted.promise
+  const closePromise = indexer1.close()
+  batchGate.resolve()
+  await closePromise
+  assert.ok(entries1.length > 0, 'test setup: a batch was in flight at close')
+  // RocksDB locks the storage directory, so close before re-opening
+  await core.close()
+
+  const reopened = trackCore(new Hypercore(coreDir))
+  /** @type {Entry[]} */
+  const entries2 = []
+  const indexer2 = new MultiCoreIndexer([reopened], {
+    batch: async (data) => {
+      entries2.push(...data)
+    },
+    storage: storageDir,
+  })
+  await indexer2.idle()
+  await indexer2.close()
+  const all = [...entries1, ...entries2]
+  assert.deepEqual(
+    sortEntries(uniqueEntries(all)),
+    sortEntries(expected),
+    'every entry is delivered at least once across restarts'
+  )
+  assert.ok(
+    all.length >= expected.length,
+    'entries from the unfinished batch may be re-delivered (at-least-once)'
+  )
+})
+
+test("Without an 'error' listener the error is uncaught, but close() still resolves", async () => {
+  // Runs in a child process: with no 'error' listener the error is
+  // (intentionally) thrown as an uncaught exception, which would fail this
+  // test process. The child traps it like a crash-reporting app would, then
+  // checks that close() still resolves.
+  const script = `
+    const MultiCoreIndexer = require('./index.js')
+    const Hypercore = require('hypercore')
+    const { mkdtempSync } = require('node:fs')
+    const { tmpdir } = require('node:os')
+    const { join } = require('node:path')
+    process.on('uncaughtException', (err) => {
+      console.log('uncaught:' + err.message)
+    })
+    async function main() {
+      const core = new Hypercore(mkdtempSync(join(tmpdir(), 'mci-core-')))
+      await core.ready()
+      await core.append(['a', 'b', 'c'])
+      const indexer = new MultiCoreIndexer([core], {
+        batch: async () => {
+          throw new Error('batch failed')
+        },
+        storage: mkdtempSync(join(tmpdir(), 'mci-index-')),
+      })
+      const timeout = setTimeout(() => {
+        console.log('close-hung')
+        process.exit(1)
+      }, 8000)
+      // The indexer closes itself when the error fires
+      while (indexer.state.current === 'indexing' || indexer.state.current === 'idle') {
+        await new Promise((res) => setTimeout(res, 10))
+      }
+      await indexer.close()
+      clearTimeout(timeout)
+      console.log('close-resolved')
+      await core.close()
+      process.exit(0)
+    }
+    main()
+  `
+  const result = spawnSync(process.execPath, ['-e', script], {
+    cwd: path.join(__dirname, '..'),
+    encoding: 'utf8',
+    timeout: 20_000,
+  })
+  assert.match(
+    result.stdout,
+    /uncaught:batch failed/,
+    'the batch error is thrown as an uncaught exception'
+  )
+  assert.match(result.stdout, /close-resolved/, 'close() still resolves')
+})

--- a/test/multi-core-indexer.test.js
+++ b/test/multi-core-indexer.test.js
@@ -853,6 +853,39 @@ test('Batch callback rejection emits error and indexer still closes', async () =
   assert.equal(errors.length, 1, "'error' is emitted only once")
 })
 
+test('Batch error followed by close() during teardown is still emitted', async () => {
+  const cores = await createMultiple(2)
+  await generateFixtures(cores, 100)
+  const batchError = new Error('batch failed')
+  /** @type {() => void} */
+  let onBatchRejected = () => {}
+  const batchRejected = new Promise((res) => {
+    onBatchRejected = /** @type {() => void} */ (res)
+  })
+  const indexer = new MultiCoreIndexer(cores, {
+    batch: async () => {
+      queueMicrotask(onBatchRejected)
+      throw batchError
+    },
+    storage: createTempDir(),
+  })
+  /** @type {Error[]} */
+  const errors = []
+  indexer.on('error', (error) => errors.push(error))
+  await batchRejected
+  // Land inside the window where the pipeline is tearing down from the error
+  // but the pipe callback has not yet delivered it
+  await new Promise((res) => setImmediate(res))
+  assert.throws(
+    () => indexer.addCore(cores[0]),
+    /Cannot add core/,
+    'addCore() throws while the pipeline is dying'
+  )
+  await indexer.close()
+  assert.equal(errors.length, 1, 'error preceding close() is still emitted')
+  assert.equal(errors[0], batchError)
+})
+
 test('Closing a core while indexing: indexer idles, resumes after reopen', async () => {
   const coreDir = createTempDir()
   const storageDir = createTempDir()

--- a/test/unit-tests/bitfield.test.js
+++ b/test/unit-tests/bitfield.test.js
@@ -86,3 +86,77 @@ test('bitfield - reload', async function () {
     assert.ok(b.get(1424242424))
   }
 })
+
+// Regression test: bits set while a flush's writes are in flight used to be
+// dropped from the unflushed queue when the flush completed, so they were
+// never persisted by any later flush
+test('bitfield - bits set during in-flight flush are persisted', async function () {
+  const createRAM = ram.reusable()
+  const storage = makeSlowWriteStorage(createRAM('bitfield'))
+
+  const b = await Bitfield.open(storage)
+  b.set(10, true)
+  storage.slowWrites = true
+  const flushPromise = b.flush()
+  // These are set while the writes for the first flush are still in flight
+  b.set(20, true)
+  b.set(40000, true)
+  await flushPromise
+  storage.slowWrites = false
+  await b.flush()
+  await b.close()
+
+  const reloaded = await Bitfield.open(createRAM('bitfield'))
+  assert.ok(reloaded.get(10), 'bit set before flush is persisted')
+  assert.ok(reloaded.get(20), 'bit set during in-flight flush is persisted')
+  assert.ok(
+    reloaded.get(40000),
+    'bit on another page set during in-flight flush is persisted'
+  )
+})
+
+test('bitfield - failed flush is retried by the next flush', async function () {
+  const createRAM = ram.reusable()
+  const storage = makeSlowWriteStorage(createRAM('bitfield'))
+
+  const b = await Bitfield.open(storage)
+  b.set(10, true)
+  b.set(40000, true)
+  storage.failWrites = true
+  await assert.rejects(() => b.flush(), /write failed/)
+  storage.failWrites = false
+  await b.flush()
+  await b.close()
+
+  const reloaded = await Bitfield.open(createRAM('bitfield'))
+  assert.ok(reloaded.get(10), 'bit is persisted by the retried flush')
+  assert.ok(reloaded.get(40000), 'bit on another page is persisted too')
+})
+
+/**
+ * Patch a storage so that writes can be slowed by a couple of ticks (to
+ * interleave set() calls with an in-flight flush) or failed (to test flush
+ * error handling)
+ *
+ * @param {InstanceType<typeof ram>} storage
+ */
+function makeSlowWriteStorage(storage) {
+  const originalWrite = storage._write.bind(storage)
+  const patched = Object.assign(storage, {
+    slowWrites: false,
+    failWrites: false,
+    /** @param {any} req */
+    _write(req) {
+      if (patched.failWrites) {
+        process.nextTick(() => req.callback(new Error('write failed')))
+        return
+      }
+      if (patched.slowWrites) {
+        setImmediate(() => setImmediate(() => originalWrite(req)))
+        return
+      }
+      originalWrite(req)
+    },
+  })
+  return patched
+}

--- a/test/unit-tests/bitfield.test.js
+++ b/test/unit-tests/bitfield.test.js
@@ -1,7 +1,11 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
+const { promisify } = require('node:util')
 const ram = require('random-access-memory')
 const Bitfield = require('../../lib/bitfield')
+
+/** @param {InstanceType<typeof ram>} storage */
+const closeStorage = (storage) => promisify(storage.close.bind(storage))()
 
 test('bitfield - set and get', async function () {
   const b = await Bitfield.open(new ram())
@@ -19,6 +23,37 @@ test('bitfield - set and get', async function () {
   assert.equal(b.get(42000000), false)
 
   await b.flush()
+})
+
+test('bitfield - setting a bit to its current value is a no-op', async function () {
+  const b = await Bitfield.open(new ram())
+
+  b.set(42, true)
+  await b.flush()
+  // Same value again: the page must not be re-dirtied, so the next flush has
+  // nothing to write
+  b.set(42, true)
+  assert.ok(b.get(42))
+
+  // Setting false on an index whose page was never created is also a no-op
+  b.set(42000000, false)
+  assert.equal(b.get(42000000), false)
+
+  await b.flush()
+})
+
+test('bitfield - open rejects if reading storage fails', async function () {
+  const storage = new ram()
+  const b = await Bitfield.open(storage)
+  b.set(42, true)
+  await b.flush()
+
+  const readError = new Error('read failed')
+  // @ts-ignore - patching the internal read method to fail
+  storage._read = (req) => {
+    process.nextTick(() => req.callback(readError))
+  }
+  await assert.rejects(() => Bitfield.open(storage), /read failed/)
 })
 
 test('bitfield - set and get, no storage', async function () {
@@ -104,7 +139,7 @@ test('bitfield - bits set during in-flight flush are persisted', async function 
   await flushPromise
   storage.slowWrites = false
   await b.flush()
-  await b.close()
+  await closeStorage(storage)
 
   const reloaded = await Bitfield.open(createRAM('bitfield'))
   assert.ok(reloaded.get(10), 'bit set before flush is persisted')
@@ -126,7 +161,7 @@ test('bitfield - failed flush is retried by the next flush', async function () {
   await assert.rejects(() => b.flush(), /write failed/)
   storage.failWrites = false
   await b.flush()
-  await b.close()
+  await closeStorage(storage)
 
   const reloaded = await Bitfield.open(createRAM('bitfield'))
   assert.ok(reloaded.get(10), 'bit is persisted by the retried flush')

--- a/test/unit-tests/core-index-stream.test.js
+++ b/test/unit-tests/core-index-stream.test.js
@@ -6,11 +6,18 @@ const { once } = require('events')
 const ram = require('random-access-memory')
 const {
   create,
+  createTempDir,
+  trackCore,
+  closeCreatedCores,
   replicate,
   generateFixture,
   throttledDrain,
 } = require('../helpers')
 const Hypercore = require('hypercore')
+
+// Cores are backed by RocksDB storage: close them after each test so native
+// resources don't accumulate across tests
+test.afterEach(() => closeCreatedCores())
 
 test('stream.core', async () => {
   const a = await create()
@@ -24,7 +31,7 @@ test('destroy before open', async () => {
     storageCreated = true
     return new ram()
   }
-  const a = new Hypercore(() => new ram())
+  const a = trackCore(new Hypercore(createTempDir()))
   const stream = new CoreIndexStream(a, createStorage, false)
   stream.destroy()
   await once(stream, 'close')
@@ -37,7 +44,7 @@ test('unlink before open', async () => {
     storageCreated = true
     return new ram()
   }
-  const core = new Hypercore(() => new ram())
+  const core = trackCore(new Hypercore(createTempDir()))
   const stream = new CoreIndexStream(core, createStorage, false)
   await stream.unlink()
   assert.equal(storageCreated, true, 'storage was created')
@@ -173,8 +180,16 @@ test("'indexing' and 'drained' events are paired", async () => {
   })
   stream.resume()
 
-  const range = b.download({ start: 0, end: a.length })
-  await Promise.all([range.downloaded(), throttledDrain(stream)])
+  // Download in separate waves, draining in between, so that the stream goes
+  // through multiple indexing -> drained cycles
+  for (const [start, end] of [
+    [0, 30],
+    [30, 60],
+    [60, 100],
+  ]) {
+    const range = b.download({ start, end })
+    await Promise.all([range.downloaded(), throttledDrain(stream)])
+  }
 
   assert.equal(indexingEvents, idleEvents)
   // This is just to check that we're actually testing something
@@ -248,3 +263,50 @@ function blocksToExpected(blocks, key) {
     index: i,
   }))
 }
+
+test('Core closed while reads are pending: blocks are skipped without error', async (t) => {
+  const a = await create()
+  await a.append(generateFixture(0, 10))
+  /** @type {Promise<void> | undefined} */
+  let closePromise
+  const originalGet = a.get.bind(a)
+  // Trigger close from inside the first read: core.close() sets `closing`
+  // synchronously, so the read below rejects the same way as an in-flight
+  // read of a core that is closed while indexing
+  // @ts-ignore - patching for the test
+  a.get = (index, opts) => {
+    closePromise ??= a.close()
+    return originalGet(index, opts)
+  }
+  const stream = new CoreIndexStream(a, () => new ram(), false)
+  t.after(() => stream.destroy())
+  /** @type {Error[]} */
+  const errors = []
+  stream.on('error', (err) => errors.push(err))
+  stream.on('data', () => assert.fail('no entries should be pushed'))
+  await once(stream, 'drained')
+  assert.equal(errors.length, 0, 'read rejections from the close are skipped')
+  assert.equal(stream.remaining, 0)
+  await closePromise
+})
+
+test('A core read failure not caused by closing destroys the stream', async (t) => {
+  const a = await create()
+  await a.append(generateFixture(0, 10))
+  const readError = Object.assign(new Error('EIO: i/o error, read'), {
+    code: 'EIO',
+  })
+  const originalGet = a.get.bind(a)
+  // Simulate a storage-level read failure for a single block. The real
+  // storage layer (RocksDB) is native code whose failures cannot be injected
+  // from a test, but its failure mode at this boundary is a rejected get()
+  // on a core that is not closing
+  // @ts-ignore - patching for the test
+  a.get = (index, opts) =>
+    index === 3 ? Promise.reject(readError) : originalGet(index, opts)
+  const stream = new CoreIndexStream(a, () => new ram(), false)
+  t.after(() => stream.destroy())
+  stream.resume()
+  const [err] = await once(stream, 'error')
+  assert.equal(err, readError, 'the stream is destroyed with the read error')
+})

--- a/test/unit-tests/multi-core-index-stream.test.js
+++ b/test/unit-tests/multi-core-index-stream.test.js
@@ -248,6 +248,41 @@ test('Source stream errors after destroy() are ignored', async () => {
   assert.equal(errors.length, 0, 'source error is not forwarded')
 })
 
+test("'destroying' is emitted synchronously when a source starts dying", async () => {
+  const core = await create()
+  const stream = new CoreIndexStream(core, () => new ram(), false)
+  const multi = new MultiCoreIndexStream([stream])
+  multi.on('error', () => {})
+  let emitted = 0
+  multi.on('destroying', () => emitted++)
+  stream.destroy(new Error('read failed'))
+  assert.equal(
+    emitted,
+    1,
+    "forwarded from the source's predestroy, before its teardown completes"
+  )
+  // catch: once() rejects on the 'error' event emitted before 'close'
+  await once(multi, 'close').catch(() => {})
+  assert.equal(emitted, 1, 'not re-emitted when the multi stream itself dies')
+})
+
+test('addStream() after destroy() throws', async () => {
+  const [coreA, coreB] = await createMultiple(2)
+  const streamA = new CoreIndexStream(coreA, () => new ram(), false)
+  const streamB = new CoreIndexStream(coreB, () => new ram(), false)
+  const multi = new MultiCoreIndexStream([streamA])
+  multi.on('error', () => {})
+  multi.destroy(new Error('pipeline error'))
+  assert.throws(
+    () => multi.addStream(streamB),
+    /Cannot add stream/,
+    'a stream added during teardown would never be destroyed'
+  )
+  // catch: once() rejects on the 'error' event emitted before 'close'
+  await once(multi, 'close').catch(() => {})
+  await destroyStream(streamB)
+})
+
 /**
  * Destroy a stream and wait for it to close
  *

--- a/test/unit-tests/multi-core-index-stream.test.js
+++ b/test/unit-tests/multi-core-index-stream.test.js
@@ -6,8 +6,13 @@ const assert = require('node:assert/strict')
 const { once } = require('events')
 const ram = require('random-access-memory')
 const { Writable } = require('streamx')
+
+// Cores are backed by RocksDB storage: close them after each test so native
+// resources don't accumulate across tests
+test.afterEach(() => closeCreatedCores())
 const {
   create,
+  closeCreatedCores,
   replicate,
   createMultiple,
   generateFixtures,
@@ -103,13 +108,14 @@ test('.remaining is as expected', async () => {
   await once(ws, 'close').catch(() => {})
 })
 
-test('Indexes items appended after initial index', async () => {
+test('Indexes items appended after initial index', async (t) => {
   const cores = await createMultiple(5)
   const indexStreams = cores.map(
     (core) => new CoreIndexStream(core, () => new ram(), false)
   )
   const entries = []
   const stream = new MultiCoreIndexStream(indexStreams, { highWaterMark: 10 })
+  t.after(() => destroyStream(stream))
   stream.on('data', (entry) => entries.push(entry))
   await throttledDrain(stream)
   assert.deepEqual(entries, [], 'no entries before append')
@@ -120,7 +126,7 @@ test('Indexes items appended after initial index', async () => {
   await once(stream, 'close')
 })
 
-test('index sparse hypercores', async () => {
+test('index sparse hypercores', async (t) => {
   const coreCount = 5
   const localCores = await createMultiple(coreCount)
   const expected = []
@@ -142,6 +148,7 @@ test('index sparse hypercores', async () => {
   }
   const entries = []
   const stream = new MultiCoreIndexStream(indexStreams, { highWaterMark: 10 })
+  t.after(() => destroyStream(stream))
   stream.on('data', (entry) => entries.push(entry))
   await throttledDrain(stream)
 
@@ -160,7 +167,7 @@ test('index sparse hypercores', async () => {
   )
 })
 
-test('Appends from a replicated core are indexed', async () => {
+test('Appends from a replicated core are indexed', async (t) => {
   const coreCount = 5
   const localCores = await createMultiple(coreCount)
   const expected1 = await generateFixtures(localCores, 50)
@@ -176,6 +183,7 @@ test('Appends from a replicated core are indexed', async () => {
   }
   const entries = []
   const stream = new MultiCoreIndexStream(indexStreams, { highWaterMark: 10 })
+  t.after(() => destroyStream(stream))
   stream.on('data', (entry) => entries.push(entry))
   await throttledDrain(stream)
 
@@ -193,7 +201,7 @@ test('Appends from a replicated core are indexed', async () => {
   )
 })
 
-test('Maintains index state', async () => {
+test('Maintains index state', async (t) => {
   const cores = await createMultiple(5)
   const storages = []
   await generateFixtures(cores, 1000)
@@ -214,6 +222,7 @@ test('Maintains index state', async () => {
     (core, i) => new CoreIndexStream(core, storages[i], false)
   )
   const stream = new MultiCoreIndexStream(indexStreams)
+  t.after(() => destroyStream(stream))
   stream.on('data', (entry) => {
     entries.push(entry)
     stream.setIndexed(entry.key.toString('hex'), entry.index)
@@ -224,3 +233,28 @@ test('Maintains index state', async () => {
   const expected = await expectedPromise
   assert.deepEqual(sortEntries(entries), sortEntries(expected))
 })
+
+test('Source stream errors after destroy() are ignored', async () => {
+  const core = await create()
+  const stream = new CoreIndexStream(core, () => new ram(), false)
+  const multi = new MultiCoreIndexStream([stream])
+  /** @type {Error[]} */
+  const errors = []
+  multi.on('error', (err) => errors.push(err))
+  multi.destroy()
+  // Emitted in the window between destroy() and teardown removing listeners
+  stream.emit('error', new Error('source error during teardown'))
+  await once(multi, 'close')
+  assert.equal(errors.length, 0, 'source error is not forwarded')
+})
+
+/**
+ * Destroy a stream and wait for it to close
+ *
+ * @param {import('streamx').Readable} stream
+ */
+async function destroyStream(stream) {
+  if (stream.destroyed) return
+  stream.destroy()
+  await once(stream, 'close')
+}


### PR DESCRIPTION
Upgrades hypercore from 10 to 11. Tests now run against real disk storage instead of random-access-memory.

Indexing throughput, 100,000 blocks, cores on disk in both versions:

| Cores × blocks | hypercore 10.17.0 (a0d19ad) | hypercore 11.35.0 (70aed05) | Speedup   |
| -------------- | --------------------------- | --------------------------- | --------- |
| 1 × 100,000    | 3,515 ms — 28,400 blocks/s  | 1,589 ms — 62,900 blocks/s  | **2.21×** |
| 5 × 20,000     | 1,652 ms — 60,500 blocks/s  | 807 ms — 124,000 blocks/s   | **2.05×** |
| 20 × 5,000     | 1,771 ms — 56,500 blocks/s  | 827 ms — 121,000 blocks/s   | **2.14×** |

BREAKING CHANGE: consumers must pass hypercore 11 cores (added as a peer dependency).

BREAKING CHANGE: indexer now emits an `'error'` event which must be handled — or deliberately left unhandled so the process crashes.

Error handling should probably either surface to the app or retry if it's I/O related like ENOSPC, EACESS or EIO. An uncaught error might be the safest for now - it would force an app restart, and be reported to Sentry; later we can attach a listener and retry I/O-class errors.

The upgrade also surfaced some existing bugs and introduced some new bugs, which are fixed in this PR:

- Index state written during an in-flight flush was permanently lost, triggered by a batch completing while the previous flush was still writing. The affected page's dirty flag was left stuck, so no later change to that page was ever persisted. This would have been hidden in production because the only symptom is silently re-indexing already-indexed entries on the next start. Found when a new error-handling test hung on it.
- Unhandled 'error' events — we don't listen for errors on the internal streams, so a rejecting batch function, a failing core read, or a failing index-storage write (e.g. disk full) became an uncaught exception. We haven't seen this in production according to our Sentry logs, but this could just be luck. Errors are now forwarded to an indexer 'error' event, pending idle() promises reject, and the indexer closes itself. Errors are emitted on a queued microtask to avoid interrupting the streamx destroy, which would cause close() to hang.
- `close()` was not idempotent - not really surfacing in any current usage, but worth fixing because a second call would resolve before the indexer had finished closing.
- closing during indexing - we've never really handled this correctly. It would have been a crash on hypercore 10, and became a silent error with hypercore 11, possible when closing a project during indexing. The indexer now reaches idle, and a new indexer over the same storage resumes from the persisted state.
- Entries delivered again after closing mid-batch -- this has always been the behaviour, but we documented "entries delivered exactly once", but the code is actually "entries delivered at least once" - corrected in the readme.
- double counting progress — with newer streamx (2.28), event listeners can run between an entry being pushed and the read index being incremented, momentarily double-counting that entry in remaining. State accounting is reordered to close the window, and the streamx range bumped to ^2.28.0. The old ^2.15.0 range already resolves to 2.28 on fresh installs, so this was existing on main.

Error paths are now covered by deterministic tests: simulated ENOSPC on index storage writes, EIO on core reads, cores closed mid-index and mid-read, closing mid-batch with restart, and a child-process test for the no-listener crash case.